### PR TITLE
[v0.0.8] Fix open ai error response parsing

### DIFF
--- a/internal/provider/openai/response.go
+++ b/internal/provider/openai/response.go
@@ -27,11 +27,10 @@ type ChatCompletionResponse struct {
 }
 
 type ErrorContent struct {
-	Message         string `json:"message"`
-	Type            string `json:"type,omitempty"`
-	Param           string `json:"param,omitempty"`
-	Code            int    `json:"code,omitempty"`
-	InternalMessage string `json:"internal_message,omitempty"`
+	Message string  `json:"message"`
+	Type    string  `json:"type,omitempty"`
+	Param   *string `json:"param,omitempty"`
+	Code    any     `json:"code,omitempty"`
 }
 
 type ChatCompletionErrorResponse struct {

--- a/internal/server/web/proxy.go
+++ b/internal/server/web/proxy.go
@@ -123,8 +123,6 @@ func getOpenAiProxyHandler(r recorder, prod, private bool, credential string, cl
 			err = json.Unmarshal(bytes, errorRes)
 			if err != nil {
 				logError(log, "error when unmarshalling openai http error response body", prod, id, err)
-				JSON(c, http.StatusInternalServerError, "[BricksLLM] failed to parse openai error response")
-				return
 			}
 
 			logOpenAiError(log, prod, id, errorRes)


### PR DESCRIPTION
## Context
- https://github.com/bricks-cloud/BricksLLM/issues/7
The problem is caused by OpenAI responding non int for error response field `code`

## Tasks
- [x] Updated OpenAI proxy not to return BricksLLM internal error code when there is an error with parsing OpenAI error response.
- [x] Updated OpenAI error response struct field `code` from `int` to `any`