### PR TITLE
[v1.0.4] Support querying by model and keyid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,20 @@
+## 1.0.4 - 2023-11-20
+### Fixed
+- Fixed configuration not found inconsistency with key and provider settings
+
+- ### Changed
+- Updated admin server to pull configurations every 5 sec by default
+- Updated prod Dockerfile to have privacy mode turned on
+
+- ### Added
+- Added a default OpenAI proxy timeout of 180s
+- Added model and keyId filters to the metrics API
+- Added health check endpoints for both admin and proxy servers
+- Started recording path and method for each proxy request
+
 ## 1.0.3 - 2023-11-09
 ### Fixed
 - Fixed Datadog tags being in the wrong format
-
 
 ## 1.0.2 - 2023-11-09
 ### Added

--- a/Dockerfile.datadog
+++ b/Dockerfile.datadog
@@ -14,4 +14,4 @@ COPY --from=datadog/serverless-init:1-alpine /datadog-init /go/bin/datadog-init
 EXPOSE 8001 8002
 ENTRYPOINT ["/go/bin/datadog-init"]
 
-CMD ["/go/bin/bricksllm", "-m", "production", "-p", "verbose"]
+CMD ["/go/bin/bricksllm", "-m", "production"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,3 +12,5 @@ WORKDIR /usr/bin
 COPY --from=build /go/src/github.com/bricks-cloud/bricksllm/bin /go/bin
 EXPOSE 8001 8002
 ENTRYPOINT ["/go/bin/bricksllm"]
+
+CMD ["-p", "verbose"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -13,4 +13,4 @@ COPY --from=build /go/src/github.com/bricks-cloud/bricksllm/bin /go/bin
 EXPOSE 8001 8002
 ENTRYPOINT ["/go/bin/bricksllm"]
 
-CMD ["-m", "production", "-p", "verbose"]
+CMD ["-m", "production"]

--- a/cmd/bricksllm/main.go
+++ b/cmd/bricksllm/main.go
@@ -136,10 +136,7 @@ func main() {
 		log.Sugar().Fatalf("error creating admin http server: %v", err)
 	}
 
-	tc, err := openai.NewTokenCounter()
-	if err != nil {
-		log.Sugar().Fatalf("error creating token counter: %v", err)
-	}
+	tc := openai.NewTokenCounter()
 
 	as.Run()
 
@@ -148,7 +145,7 @@ func main() {
 	rec := recorder.NewRecorder(costStorage, costLimitCache, ce, store)
 	rlm := manager.NewRateLimitManager(rateLimitCache)
 
-	ps, err := web.NewProxyServer(log, *modePtr, *privacyPtr, m, psm, store, memStore, ce, v, rec, cfg.OpenAiKey, e, rlm)
+	ps, err := web.NewProxyServer(log, *modePtr, *privacyPtr, m, psm, store, memStore, ce, v, rec, cfg.OpenAiKey, e, rlm, cfg.ProxyTimeout)
 	if err != nil {
 		log.Sugar().Fatalf("error creating proxy http server: %v", err)
 	}

--- a/cmd/tool/main.go
+++ b/cmd/tool/main.go
@@ -135,10 +135,7 @@ func main() {
 		log.Sugar().Fatalf("error creating admin http server: %v", err)
 	}
 
-	tc, err := openai.NewTokenCounter()
-	if err != nil {
-		log.Sugar().Fatalf("error creating token counter: %v", err)
-	}
+	tc := openai.NewTokenCounter()
 
 	as.Run()
 
@@ -147,7 +144,7 @@ func main() {
 	rec := recorder.NewRecorder(costStorage, costLimitCache, ce, store)
 	rlm := manager.NewRateLimitManager(rateLimitCache)
 
-	ps, err := web.NewProxyServer(log, *modePtr, *privacyPtr, m, psm, store, memStore, ce, v, rec, cfg.OpenAiKey, e, rlm)
+	ps, err := web.NewProxyServer(log, *modePtr, *privacyPtr, m, psm, store, memStore, ce, v, rec, cfg.OpenAiKey, e, rlm, cfg.ProxyTimeout)
 	if err != nil {
 		log.Sugar().Fatalf("error creating proxy http server: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,21 @@ module github.com/bricks-cloud/bricksllm
 go 1.19
 
 require (
+	github.com/DataDog/datadog-go/v5 v5.3.0
 	github.com/caarlos0/env v3.5.0+incompatible
 	github.com/fatih/color v1.15.0
 	github.com/gin-gonic/gin v1.9.1
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-colorable v0.1.13
-	github.com/pkoukk/tiktoken-go v0.1.5
 	github.com/pkoukk/tiktoken-go-loader v0.0.1
 	github.com/redis/go-redis/v9 v9.0.5
+	github.com/sashabaranov/go-openai v1.17.7
+	github.com/stretchr/testify v1.8.4
 	go.uber.org/zap v1.24.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/DataDog/datadog-go/v5 v5.3.0 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -38,10 +38,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
+	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sashabaranov/go-openai v1.17.1 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
@@ -52,4 +50,5 @@ require (
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,11 +67,12 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkoukk/tiktoken-go v0.1.5 h1:hAlT4dCf6Uk50x8E7HQrddhH3EWMKUN+LArExQQsQx4=
 github.com/pkoukk/tiktoken-go v0.1.5/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
+github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
+github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pkoukk/tiktoken-go-loader v0.0.1 h1:aOB2gRFzZTCCPi3YsOQXJO771P/5876JAsdebMyazig=
 github.com/pkoukk/tiktoken-go-loader v0.0.1/go.mod h1:4mIkYyZooFlnenDlormIo6cd5wrlUKNr97wp9nGgEKo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -80,6 +81,8 @@ github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/sashabaranov/go-openai v1.17.1 h1:tapFKbKE8ep0/qGkKp5Q3TtxWUD7m9VIFe9YACQYLbA=
 github.com/sashabaranov/go-openai v1.17.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.17.7 h1:MPcAwlwbeo7ZmhQczoOgZBHtIBY1TfZqsdx6+/ndloM=
+github.com/sashabaranov/go-openai v1.17.7/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -92,7 +95,6 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
@@ -145,7 +147,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	PostgresqlPort           string        `env:"POSTGRESQL_PORT" envDefault:"5432"`
 	RedisHosts               string        `env:"REDIS_HOSTS" envSeparator:":" envDefault:"localhost"`
 	RedisPort                string        `env:"REDIS_PORT" envDefault:"6379"`
+	RedisUsername            string        `env:"REDIS_USERNAME"`
 	RedisPassword            string        `env:"REDIS_PASSWORD"`
 	RedisReadTimeout         time.Duration `env:"REDIS_READ_TIME_OUT" envDefault:"1s"`
 	RedisWriteTimeout        time.Duration `env:"REDIS_WRITE_TIME_OUT" envDefault:"500ms"`
@@ -23,6 +24,7 @@ type Config struct {
 	InMemoryDbUpdateInterval time.Duration `env:"IN_MEMORY_DB_UPDATE_INTERVAL" envDefault:"1s"`
 	OpenAiKey                string        `env:"OPENAI_API_KEY"`
 	StatsProvider            string        `env:"STATS_PROVIDER"`
+	ProxyTimeout             time.Duration `env:"PROXY_TIMEOUT" envDefault:"180s"`
 }
 
 func ParseEnvVariables() (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,7 +21,7 @@ type Config struct {
 	RedisWriteTimeout        time.Duration `env:"REDIS_WRITE_TIME_OUT" envDefault:"500ms"`
 	PostgresqlReadTimeout    time.Duration `env:"POSTGRESQL_READ_TIME_OUT" envDefault:"2s"`
 	PostgresqlWriteTimeout   time.Duration `env:"POSTGRESQL_WRITE_TIME_OUT" envDefault:"1s"`
-	InMemoryDbUpdateInterval time.Duration `env:"IN_MEMORY_DB_UPDATE_INTERVAL" envDefault:"1s"`
+	InMemoryDbUpdateInterval time.Duration `env:"IN_MEMORY_DB_UPDATE_INTERVAL" envDefault:"5s"`
 	OpenAiKey                string        `env:"OPENAI_API_KEY"`
 	StatsProvider            string        `env:"STATS_PROVIDER"`
 	ProxyTimeout             time.Duration `env:"PROXY_TIMEOUT" envDefault:"180s"`

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -14,4 +14,6 @@ type Event struct {
 	PromptTokenCount     int
 	CompletionTokenCount int
 	LatencyInMs          int
+	Path                 string
+	Method               string
 }

--- a/internal/event/reporting.go
+++ b/internal/event/reporting.go
@@ -7,7 +7,9 @@ type DataPoint struct {
 	LatencyInMs          int     `json:"latencyInMs"`
 	PromptTokenCount     int     `json:"promptTokenCount"`
 	CompletionTokenCount int     `json:"completionTokenCount"`
-	SuccessCouunt        int     `json:"successCount"`
+	SuccessCount         int     `json:"successCount"`
+	Model                string  `json:"model"`
+	KeyId                string  `json:"keyId"`
 }
 
 type ReportingResponse struct {
@@ -22,4 +24,5 @@ type ReportingRequest struct {
 	Start     int64    `json:"start"`
 	End       int64    `json:"end"`
 	Increment int64    `json:"increment"`
+	Filters   []string `json:"filters"`
 }

--- a/internal/manager/reporting.go
+++ b/internal/manager/reporting.go
@@ -15,7 +15,7 @@ type keyStorage interface {
 }
 
 type eventStorage interface {
-	GetEventDataPoints(start, end, increment int64, tags, keyIds []string) ([]*event.DataPoint, error)
+	GetEventDataPoints(start, end, increment int64, tags, keyIds []string, filters []string) ([]*event.DataPoint, error)
 	GetLatencyPercentiles(start, end int64, tags, keyIds []string) ([]float64, error)
 }
 
@@ -34,7 +34,7 @@ func NewReportingManager(cs costStorage, ks keyStorage, es eventStorage) *Report
 }
 
 func (rm *ReportingManager) GetEventReporting(e *event.ReportingRequest) (*event.ReportingResponse, error) {
-	dataPoints, err := rm.es.GetEventDataPoints(e.Start, e.End, e.Increment, e.Tags, e.KeyIds)
+	dataPoints, err := rm.es.GetEventDataPoints(e.Start, e.End, e.Increment, e.Tags, e.KeyIds, e.Filters)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/openai/cost.go
+++ b/internal/provider/openai/cost.go
@@ -20,6 +20,7 @@ var OpenAiPerThousandTokenCost = map[string]map[string]float64{
 		"gpt-4-32k-0613":            0.06,
 		"gpt-4-32k-0314":            0.06,
 		"gpt-3.5-turbo":             0.0015,
+		"gpt-3.5-turbo-1106":        0.001,
 		"gpt-3.5-turbo-0301":        0.0015,
 		"gpt-3.5-turbo-instruct":    0.0015,
 		"gpt-3.5-turbo-0613":        0.0015,
@@ -48,10 +49,27 @@ var OpenAiPerThousandTokenCost = map[string]map[string]float64{
 		"babbage":          0.0006,
 		"ada":              0.0004,
 	},
-	"embedding": {
-		"text-embedding-ada-002": 0.0001,
+	"embeddings": {
+		"text-embedding-ada-002":        0.0001,
+		"text-similarity-ada-001":       0.004,
+		"text-search-ada-doc-001":       0.004,
+		"text-search-ada-query-001":     0.004,
+		"code-search-ada-code-001":      0.004,
+		"code-search-ada-text-001":      0.004,
+		"code-search-babbage-code-001":  0.005,
+		"code-search-babbage-text-001":  0.005,
+		"text-similarity-babbage-001":   0.005,
+		"text-search-babbage-doc-001":   0.005,
+		"text-search-babbage-query-001": 0.005,
+		"text-similarity-curie-001":     0.02,
+		"text-search-curie-doc-001":     0.02,
+		"text-search-curie-query-001":   0.02,
+		"text-search-davinci-doc-001":   0.2,
+		"text-search-davinci-query-001": 0.2,
+		"text-similarity-davinci-001":   0.2,
 	},
 	"completion": {
+		"gpt-3.5-turbo-1106":        0.002,
 		"gpt-4-1106-preview":        0.03,
 		"gpt-4-1106-vision-preview": 0.03,
 		"gpt-4":                     0.06,
@@ -115,11 +133,26 @@ func (ce *CostEstimator) EstimatePromptCost(model string, tks int) (float64, err
 	return tksInFloat / 1000 * cost, nil
 }
 
+func (ce *CostEstimator) EstimateEmbeddingsInputCost(model string, tks int) (float64, error) {
+	costMap, ok := ce.tokenCostMap["embeddings"]
+	if !ok {
+		return 0, errors.New("embeddings token cost is not provided")
+
+	}
+
+	cost, ok := costMap[model]
+	if !ok {
+		return 0, fmt.Errorf("%s is not present in the cost map provided", model)
+	}
+
+	tksInFloat := float64(tks)
+	return tksInFloat / 1000 * cost, nil
+}
+
 func (ce *CostEstimator) EstimateCompletionCost(model string, tks int) (float64, error) {
 	costMap, ok := ce.tokenCostMap["completion"]
 	if !ok {
 		return 0, errors.New("prompt token cost is not provided")
-
 	}
 
 	cost, ok := costMap[model]
@@ -141,6 +174,35 @@ func (ce *CostEstimator) EstimateChatCompletionPromptCost(r *goopenai.ChatComple
 		return 0, err
 	}
 	return ce.EstimatePromptCost(r.Model, tks)
+}
+
+func (ce *CostEstimator) EstimateEmbeddingsCost(r *goopenai.EmbeddingRequest) (float64, error) {
+	if len(r.Model.String()) == 0 {
+		return 0, errors.New("model is not provided")
+	}
+
+	if inputs, ok := r.Input.([]string); ok {
+		total := 0
+		for _, input := range inputs {
+			tks, err := ce.tc.Count(r.Model.String(), input)
+			if err != nil {
+				return 0, err
+			}
+
+			total += tks
+		}
+
+		return ce.EstimateEmbeddingsInputCost(r.Model.String(), total)
+	} else if input, ok := r.Input.(string); ok {
+		tks, err := ce.tc.Count(r.Model.String(), input)
+		if err != nil {
+			return 0, err
+		}
+
+		return ce.EstimateEmbeddingsInputCost(r.Model.String(), tks)
+	}
+
+	return 0, errors.New("input format is not recognized")
 }
 
 func countFunctionTokens(r *goopenai.ChatCompletionRequest, tc tokenCounter) (int, error) {

--- a/internal/server/web/admin.go
+++ b/internal/server/web/admin.go
@@ -155,7 +155,7 @@ func getGetKeysHandler(m KeyManager, log *zap.Logger, prod bool) gin.HandlerFunc
 	}
 }
 
-type ValidationError interface {
+type validationError interface {
 	Error() string
 	Validation()
 }
@@ -220,7 +220,7 @@ func getCreateProviderSettingHandler(m ProviderSettingsManager, log *zap.Logger,
 				}, 1)
 			}()
 
-			if _, ok := err.(ValidationError); ok {
+			if _, ok := err.(validationError); ok {
 				errType = "validation"
 
 				c.JSON(http.StatusBadRequest, &ErrorResponse{
@@ -310,7 +310,7 @@ func getCreateKeyHandler(m KeyManager, log *zap.Logger, prod bool) gin.HandlerFu
 				}, 1)
 			}()
 
-			if _, ok := err.(ValidationError); ok {
+			if _, ok := err.(validationError); ok {
 				errType = "validation"
 
 				c.JSON(http.StatusBadRequest, &ErrorResponse{
@@ -414,7 +414,19 @@ func getUpdateProviderSettingHandler(m ProviderSettingsManager, log *zap.Logger,
 				}, 1)
 			}()
 
-			if _, ok := err.(ValidationError); ok {
+			if _, ok := err.(notFoundError); ok {
+				errType = "not_found"
+				c.JSON(http.StatusNotFound, &ErrorResponse{
+					Type:     "/errors/not-found",
+					Title:    "update provider setting failed",
+					Status:   http.StatusNotFound,
+					Detail:   err.Error(),
+					Instance: path,
+				})
+				return
+			}
+
+			if _, ok := err.(validationError); ok {
 				errType = "validation"
 				c.JSON(http.StatusBadRequest, &ErrorResponse{
 					Type:     "/errors/validation",
@@ -515,7 +527,7 @@ func getUpdateKeyHandler(m KeyManager, log *zap.Logger, prod bool) gin.HandlerFu
 				}, 1)
 			}()
 
-			if _, ok := err.(ValidationError); ok {
+			if _, ok := err.(validationError); ok {
 				errType = "validation"
 				c.JSON(http.StatusBadRequest, &ErrorResponse{
 					Type:     "/errors/validation",
@@ -529,7 +541,6 @@ func getUpdateKeyHandler(m KeyManager, log *zap.Logger, prod bool) gin.HandlerFu
 
 			if _, ok := err.(notFoundError); ok {
 				errType = "not_found"
-
 				c.JSON(http.StatusNotFound, &ErrorResponse{
 					Type:     "/errors/not-found",
 					Title:    "update key failed",

--- a/internal/server/web/assistant.go
+++ b/internal/server/web/assistant.go
@@ -1,0 +1,168 @@
+package web
+
+import (
+	"encoding/json"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func logCreateAssistantRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	ar := &goopenai.AssistantRequest{}
+	err := json.Unmarshal(data, ar)
+	if err != nil {
+		logError(log, "error when unmarshalling assistant request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("model", ar.Model),
+			zap.Any("tools", ar.Tools),
+			zap.Any("file_ids", ar.FileIDs),
+			zap.Any("metadata", ar.Metadata),
+			zap.Stringp("name", ar.Name),
+			zap.Stringp("description", ar.Description),
+		}
+
+		if !private && ar.Instructions != nil {
+			fields = append(fields, zap.String("instructions", *ar.Instructions))
+		}
+
+		log.Info("openai create assistant request", fields...)
+	}
+}
+
+func logAssistantResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	a := &goopenai.Assistant{}
+	err := json.Unmarshal(data, a)
+	if err != nil {
+		logError(log, "error when unmarshalling assistant response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", cid),
+			zap.String("object", a.Object),
+			zap.Int64("created_at", a.CreatedAt),
+			zap.String("Model", a.Model),
+			zap.Any("tools", a.Tools),
+			zap.Stringp("name", a.Name),
+			zap.Stringp("description", a.Description),
+		}
+
+		if !private && a.Instructions != nil {
+			fields = append(fields, zap.String("instructions", *a.Instructions))
+		}
+
+		log.Info("openai create assistant response", fields...)
+	}
+}
+
+func logRetrieveAssistantRequest(log *zap.Logger, data []byte, prod bool, cid, assistantId string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", assistantId),
+		}
+
+		log.Info("openai retrieve assistant request", fields...)
+	}
+}
+
+func logModifyAssistantRequest(log *zap.Logger, data []byte, prod, private bool, cid, assistantId string) {
+	ar := &goopenai.AssistantRequest{}
+	err := json.Unmarshal(data, ar)
+	if err != nil {
+		logError(log, "error when unmarshalling modifying assistant request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", assistantId),
+			zap.String("model", ar.Model),
+			zap.Any("tools", ar.Tools),
+			zap.Any("file_ids", ar.FileIDs),
+			zap.Any("metadata", ar.Metadata),
+			zap.Stringp("name", ar.Name),
+			zap.Stringp("description", ar.Description),
+		}
+
+		if !private && ar.Instructions != nil {
+			fields = append(fields, zap.String("instructions", *ar.Instructions))
+		}
+
+		log.Info("openai modify assistant request", fields...)
+	}
+}
+
+func logDeleteAssistantRequest(log *zap.Logger, data []byte, prod bool, cid, assistantId string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", assistantId),
+		}
+
+		log.Info("openai delete assistant request", fields...)
+	}
+}
+
+func logDeleteAssistantResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	adr := &goopenai.AssistantDeleteResponse{}
+	err := json.Unmarshal(data, adr)
+	if err != nil {
+		logError(log, "error when unmarshalling assistant deletion response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", adr.ID),
+			zap.String("object", adr.Object),
+			zap.Bool("deleted", adr.Deleted),
+		}
+
+		log.Info("openai assistant deletion response", fields...)
+	}
+}
+
+func logListAssistantsRequest(log *zap.Logger, prod bool, cid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+		}
+
+		log.Info("openai list assistants request", fields...)
+	}
+}
+
+func logListAssistantsResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	assistants := &goopenai.AssistantsList{}
+	err := json.Unmarshal(data, assistants)
+	if err != nil {
+		logError(log, "error when unmarshalling list assistants response", prod, cid, err)
+		return
+	}
+
+	for _, assistant := range assistants.Assistants {
+		if private {
+			assistant.Instructions = nil
+		}
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("assistants", assistants.Assistants),
+		}
+
+		log.Info("openai list assistants response", fields...)
+	}
+}

--- a/internal/server/web/assistant_file.go
+++ b/internal/server/web/assistant_file.go
@@ -1,0 +1,27 @@
+package web
+
+import "go.uber.org/zap"
+
+func logCreateAssistantFileRequest(log *zap.Logger, prod bool, cid string) {
+}
+
+func logCreateAssistantFileResponse(log *zap.Logger, prod bool, cid string) {
+}
+
+func logRetrieveAssistantFileRequest(log *zap.Logger, prod bool, cid string) {
+}
+
+func logRetrieveAssistantFileResponse(log *zap.Logger, prod bool, cid string) {
+}
+
+func logDeleteAssistantFileRequest(log *zap.Logger, prod bool, cid string) {
+}
+
+func logDeleteAssistantFileResponse(log *zap.Logger, prod bool, cid string) {
+}
+
+func logListAssistantFilesRequest(log *zap.Logger, prod bool, cid string) {
+}
+
+func logListAssistantFilesResponse(log *zap.Logger, prod bool, cid string) {
+}

--- a/internal/server/web/message.go
+++ b/internal/server/web/message.go
@@ -1,0 +1,218 @@
+package web
+
+import (
+	"encoding/json"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func logCreateMessageRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	mr := &goopenai.MessageRequest{}
+	err := json.Unmarshal(data, mr)
+	if err != nil {
+		logError(log, "error when unmarshalling create message request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("role", mr.Role),
+			zap.Any("file_ids", mr.FileIds),
+			zap.Any("metadata", mr.Metadata),
+		}
+
+		if !private && len(mr.Content) != 0 {
+			fields = append(fields, zap.String("content", mr.Content))
+		}
+
+		log.Info("openai create message request", fields...)
+	}
+}
+
+func logMessageResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	m := &goopenai.Message{}
+	err := json.Unmarshal(data, m)
+	if err != nil {
+		logError(log, "error when unmarshalling message response", prod, cid, err)
+		return
+	}
+
+	if private {
+		for _, mc := range m.Content {
+			mc.Text = nil
+		}
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", m.ID),
+			zap.String("object", m.Object),
+			zap.Int("created_at", m.CreatedAt),
+			zap.String("role", m.Role),
+			zap.Any("content", m.Content),
+			zap.Any("file_ids", m.FileIds),
+			zap.Any("assistant_id", m.AssistantID),
+			zap.Any("run_id", m.RunID),
+			zap.Any("metadata", m.Metadata),
+		}
+
+		log.Info("openai message response", fields...)
+	}
+}
+
+func logRetrieveMessageRequest(log *zap.Logger, prod bool, cid, mid, tid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("message_id", mid),
+		}
+
+		log.Info("openai retrieve message request", fields...)
+	}
+}
+
+func logModifyMessageRequest(log *zap.Logger, data []byte, prod, private bool, cid, tid, mid string) {
+	mr := &goopenai.MessageRequest{}
+	err := json.Unmarshal(data, mr)
+	if err != nil {
+		logError(log, "error when unmarshalling modify message request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("message_id", mid),
+			zap.Any("metadata", mr.Metadata),
+		}
+
+		if !private && len(mr.Content) != 0 {
+			fields = append(fields, zap.String("content", mr.Content))
+		}
+
+		log.Info("openai modify message request", fields...)
+	}
+}
+
+func logListMessagesRequest(log *zap.Logger, data []byte, prod bool, cid, tid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+		}
+
+		log.Info("openai list messages request", fields...)
+	}
+}
+
+func logListMessagesResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	ms := &goopenai.MessagesList{}
+	err := json.Unmarshal(data, ms)
+	if err != nil {
+		logError(log, "error when unmarshalling list messages response", prod, cid, err)
+		return
+	}
+
+	for _, m := range ms.Messages {
+		if private {
+			for _, mc := range m.Content {
+				mc.Text = nil
+			}
+		}
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("messages", ms.Messages),
+		}
+
+		log.Info("openai list messages response", fields...)
+	}
+}
+
+func logRetrieveMessageFileRequest(log *zap.Logger, prod bool, cid, tid, mid, fid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("message_id", mid),
+			zap.String("file_id", fid),
+		}
+
+		log.Info("openai retrieve message file request", fields...)
+	}
+}
+
+func logRetrieveMessageFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	mf := &goopenai.MessageFile{}
+	err := json.Unmarshal(data, mf)
+	if err != nil {
+		logError(log, "error when unmarshalling message file response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", mf.ID),
+			zap.String("object", mf.Object),
+			zap.Int("created_at", mf.CreatedAt),
+			zap.String("message_id", mf.MessageID),
+		}
+
+		log.Info("openai message file response", fields...)
+	}
+}
+
+func logListMessageFilesRequest(log *zap.Logger, data []byte, prod bool, cid, tid, mid string, params map[string]string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("message_id", mid),
+		}
+
+		if v, ok := params["limit"]; ok {
+			fields = append(fields, zap.String("limit", v))
+		}
+
+		if v, ok := params["order"]; ok {
+			fields = append(fields, zap.String("order", v))
+		}
+
+		if v, ok := params["after"]; ok {
+			fields = append(fields, zap.String("after", v))
+		}
+
+		if v, ok := params["before"]; ok {
+			fields = append(fields, zap.String("before", v))
+		}
+
+		log.Info("openai list message files request", fields...)
+	}
+}
+
+func logListMessageFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	files := &goopenai.MessageFilesList{}
+	err := json.Unmarshal(data, files)
+	if err != nil {
+		logError(log, "error when unmarshalling list message files response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("message_files", files.MessageFiles),
+		}
+
+		log.Info("openai list message files response", fields...)
+	}
+}

--- a/internal/server/web/message_file.go
+++ b/internal/server/web/message_file.go
@@ -1,0 +1,1 @@
+package web

--- a/internal/server/web/run.go
+++ b/internal/server/web/run.go
@@ -1,0 +1,301 @@
+package web
+
+import (
+	"encoding/json"
+
+	goopenai "github.com/sashabaranov/go-openai"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func logCreateRunRequest(log *zap.Logger, data []byte, prod bool, cid string) {
+	rr := &goopenai.RunRequest{}
+	err := json.Unmarshal(data, rr)
+	if err != nil {
+		logError(log, "error when unmarshalling create run request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("assistant_id", rr.AssistantID),
+			zap.Stringp("instruction", rr.Instructions),
+			zap.Stringp("model", rr.Model),
+			zap.Any("tools", rr.Tools),
+			zap.Any("metadata", rr.Metadata),
+		}
+
+		log.Info("openai create run request", fields...)
+	}
+}
+
+func logRunResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	r := &goopenai.Run{}
+	err := json.Unmarshal(data, r)
+	if err != nil {
+		logError(log, "error when unmarshalling run response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", r.ID),
+			zap.String("object", r.Object),
+			zap.Int64("created_at", r.CreatedAt),
+			zap.String("thread_id", r.ThreadID),
+			zap.String("assistant_id", r.AssistantID),
+			zap.String("status", string(r.Status)),
+			zap.Any("required_action", r.RequiredAction),
+			zap.Any("last_error", r.LastError),
+			zap.Int64("expires_at", r.ExpiresAt),
+			zap.Int64p("started_at", r.StartedAt),
+			zap.Int64p("cancelled_at", r.CancelledAt),
+			zap.Int64p("failed_at", r.FailedAt),
+			zap.Int64p("completed_at", r.CompletedAt),
+			zap.String("model", r.Model),
+			zap.Any("tools", r.Tools),
+			zap.Any("file_ids", r.FileIDS),
+			zap.Any("metadata", r.Metadata),
+		}
+
+		if !private && len(r.Instructions) != 0 {
+			fields = append(fields, zap.String("instructions", r.Instructions))
+		}
+
+		log.Info("openai run response", fields...)
+	}
+}
+
+func logRetrieveRunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+		}
+
+		log.Info("openai retrieve run request", fields...)
+	}
+}
+
+func logModifyRunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+	rr := &goopenai.RunRequest{}
+	err := json.Unmarshal(data, rr)
+	if err != nil {
+		logError(log, "error when unmarshalling modify run request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+			zap.Any("metadata", rr.Metadata),
+		}
+
+		log.Info("openai modify run request", fields...)
+	}
+}
+
+func logListRunsRequest(log *zap.Logger, data []byte, prod bool, cid, tid string, params map[string]string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+		}
+
+		if v, ok := params["limit"]; ok {
+			fields = append(fields, zap.String("limit", v))
+		}
+
+		if v, ok := params["order"]; ok {
+			fields = append(fields, zap.String("order", v))
+		}
+
+		if v, ok := params["after"]; ok {
+			fields = append(fields, zap.String("after", v))
+		}
+
+		if v, ok := params["before"]; ok {
+			fields = append(fields, zap.String("before", v))
+		}
+
+		log.Info("openai list runs request", fields...)
+	}
+}
+
+func logListRunsResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	r := &goopenai.RunList{}
+	err := json.Unmarshal(data, r)
+	if err != nil {
+		logError(log, "error when unmarshalling list runs response", prod, cid, err)
+		return
+	}
+
+	if private {
+		for _, run := range r.Runs {
+			run.Instructions = ""
+		}
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("runs", r.Runs),
+		}
+
+		log.Info("openai list runs response", fields...)
+	}
+}
+
+func logSubmitToolOutputsRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+	r := &goopenai.SubmitToolOutputsRequest{}
+	err := json.Unmarshal(data, r)
+	if err != nil {
+		logError(log, "error when unmarshalling submit tool outputs request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+			zap.Any("tool_outputs", r.ToolOutputs),
+		}
+
+		log.Info("openai submit tool outputs request", fields...)
+	}
+}
+
+func logCancelARunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+		}
+
+		log.Info("openai cancel a run request", fields...)
+	}
+}
+
+func logCreateThreadAndRunRequest(log *zap.Logger, data []byte, prod, private bool, cid, tid, rid string) {
+	r := &goopenai.CreateThreadAndRunRequest{}
+	err := json.Unmarshal(data, r)
+	if err != nil {
+		logError(log, "error when unmarshalling create thread and run request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("assistant_id", r.AssistantID),
+			zap.Any("thread", r.Thread),
+			zap.Stringp("model", r.Model),
+			zap.Any("tools", r.Tools),
+			zap.Any("metadata", r.Metadata),
+		}
+
+		if !private {
+			fields = append(fields, zap.Stringp("instructions", r.Instructions))
+		}
+
+		log.Info("openai create thread and run request", fields...)
+	}
+}
+
+func logRetrieveRunStepRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid, sid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+			zap.String("step_id", sid),
+		}
+
+		log.Info("openai retrieve run step request", fields...)
+	}
+}
+
+func logRetrieveRunStepResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	rs := &goopenai.RunStep{}
+	err := json.Unmarshal(data, rs)
+	if err != nil {
+		logError(log, "error when unmarshalling retrieve run step response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", rs.ID),
+			zap.String("object", rs.Object),
+			zap.Int64("created_at", rs.CreatedAt),
+			zap.String("assistant_id", rs.AssistantID),
+			zap.String("thread_id", rs.ThreadID),
+			zap.String("run_id", rs.RunID),
+			zap.String("type", string(rs.Type)),
+			zap.String("status", string(rs.Status)),
+			zap.Any("step_details", rs.StepDetails),
+			zap.Any("last_error", rs.LastError),
+			zap.Int64p("expired_at", rs.ExpiredAt),
+			zap.Int64p("cancelled_at", rs.CancelledAt),
+			zap.Int64p("failed_at", rs.FailedAt),
+			zap.Int64p("completed_at", rs.CompletedAt),
+			zap.Any("metadata", rs.Metadata),
+		}
+
+		log.Info("openai retrieve run step request", fields...)
+	}
+}
+
+func logListRunStepsRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string, params map[string]string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("thread_id", tid),
+			zap.String("run_id", rid),
+		}
+
+		if v, ok := params["limit"]; ok {
+			fields = append(fields, zap.String("limit", v))
+		}
+
+		if v, ok := params["order"]; ok {
+			fields = append(fields, zap.String("order", v))
+		}
+
+		if v, ok := params["after"]; ok {
+			fields = append(fields, zap.String("after", v))
+		}
+
+		if v, ok := params["before"]; ok {
+			fields = append(fields, zap.String("before", v))
+		}
+
+		log.Info("openai list run steps request", fields...)
+	}
+}
+
+func logListRunStepsResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	rsl := &goopenai.RunStepList{}
+	err := json.Unmarshal(data, rsl)
+	if err != nil {
+		logError(log, "error when unmarshalling list run steps response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("run_steps", rsl.RunSteps),
+		}
+
+		log.Info("openai list run steps response", fields...)
+	}
+}

--- a/internal/server/web/thread.go
+++ b/internal/server/web/thread.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"encoding/json"
+
+	goopenai "github.com/sashabaranov/go-openai"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func logCreateThreadRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+	tr := &goopenai.ThreadRequest{}
+	err := json.Unmarshal(data, tr)
+	if err != nil {
+		logError(log, "error when unmarshalling create thread request", prod, cid, err)
+		return
+	}
+
+	if private {
+		for _, m := range tr.Messages {
+			m.Content = ""
+		}
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.Any("metadata", tr.Metadata),
+			zap.Any("messages", tr.Messages),
+		}
+
+		log.Info("openai create thread request", fields...)
+	}
+}
+
+func logThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	t := &goopenai.Thread{}
+	err := json.Unmarshal(data, t)
+	if err != nil {
+		logError(log, "error when unmarshalling thread response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", t.ID),
+			zap.String("object", t.Object),
+			zap.Int64("created_at", t.CreatedAt),
+			zap.Any("metadata", t.Metadata),
+		}
+
+		log.Info("openai create thread response", fields...)
+	}
+}
+
+func logRetrieveThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", tid),
+		}
+
+		log.Info("openai retrieve thread request", fields...)
+	}
+}
+
+func logModifyThreadRequest(log *zap.Logger, data []byte, prod bool, cid, tid string) {
+	tr := &goopenai.ThreadRequest{}
+	err := json.Unmarshal(data, tr)
+	if err != nil {
+		logError(log, "error when unmarshalling modify thread request", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", tid),
+			zap.Any("metadata", tr.Metadata),
+		}
+
+		log.Info("openai modify thread request", fields...)
+	}
+}
+
+func logDeleteThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", tid),
+		}
+
+		log.Info("openai delete thread request", fields...)
+	}
+}
+
+func logDeleteThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+	tdr := &goopenai.ThreadDeleteResponse{}
+	err := json.Unmarshal(data, tdr)
+	if err != nil {
+		logError(log, "error when unmarshalling thread deletion response", prod, cid, err)
+		return
+	}
+
+	if prod {
+		fields := []zapcore.Field{
+			zap.String(correlationId, cid),
+			zap.String("id", tdr.ID),
+			zap.String("object", tdr.Object),
+			zap.Bool("deleted", tdr.Deleted),
+		}
+
+		log.Info("openai thread deletion response", fields...)
+	}
+}

--- a/internal/storage/postgresql/postgresql.go
+++ b/internal/storage/postgresql/postgresql.go
@@ -799,12 +799,18 @@ func (s *Store) UpdateProviderSetting(id string, setting *provider.Setting) (*pr
 	updated := &provider.Setting{}
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), s.wt)
 	defer cancel()
-	if err := s.db.QueryRowContext(ctxTimeout, query, values...).Scan(
+
+	row := s.db.QueryRowContext(ctxTimeout, query, values...)
+	if err := row.Scan(
 		&updated.Id,
 		&updated.CreatedAt,
 		&updated.UpdatedAt,
 		&updated.Provider,
 	); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, internal_errors.NewNotFoundError("provider setting is not found for: " + id)
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
## Context
- Bricks pulls key and provider configurations from PostgreSQL on a periodic basis. The time stamp we used resulted in some inconsistencies in production. 
- OpenAI proxy does not have a timeout. 
- Metrics API does not support querying by model and keyId.
- Prod Dockerfile has privacy mode turned off.
- Token counting is not accurate due to not using the correct tokenizer for certain models.
- Health check endpoints are needed for k8s deployment.
- Some OpenAI endpoints do not have specific models associated with them. To effectively track OpenAI usage, we need to add path and method.

## Tasks
- [x] Update memDB to fetch configurations from postgresSQL using last update timestamp.
- [x] Add a default OpenAI proxy timeout of 180s.
- [x] Add model and keyId filters to the metrics API
- [x] Update prod Dockerfile to have privacy mode turned on
- [x] Add health check endpoints for both admin and proxy servers
- [x] Start recording path and method for each proxy request
