### PR TITLE
[V1.1.1] Add name field to provider settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The vision of BricksLLM is to support many more large language models such as LL
 ## Roadmap
 - [x] Access control via API key with rate limit, cost limit and ttl
 - [x] Logging integration
-- [x] Statsd integration :construction:
+- [x] Statsd integration
 - [ ] Routes configuration :construction:
 - [ ] PII detection and masking :construction:
 

--- a/cmd/bricksllm/main.go
+++ b/cmd/bricksllm/main.go
@@ -70,9 +70,19 @@ func main() {
 		log.Sugar().Fatalf("error creating events table: %v", err)
 	}
 
+	err = store.AlterEventsTable()
+	if err != nil {
+		log.Sugar().Fatalf("error altering events table: %v", err)
+	}
+
 	err = store.CreateProviderSettingsTable()
 	if err != nil {
 		log.Sugar().Fatalf("error creating provider settings table: %v", err)
+	}
+
+	err = store.AlterProviderSettingsTable()
+	if err != nil {
+		log.Sugar().Fatalf("error altering provider settings table: %v", err)
 	}
 
 	memStore, err := memdb.NewMemDb(store, log, cfg.InMemoryDbUpdateInterval)

--- a/cmd/tool/main.go
+++ b/cmd/tool/main.go
@@ -69,9 +69,19 @@ func main() {
 		log.Sugar().Fatalf("error creating events table: %v", err)
 	}
 
+	err = store.AlterEventsTable()
+	if err != nil {
+		log.Sugar().Fatalf("error altering events table: %v", err)
+	}
+
 	err = store.CreateProviderSettingsTable()
 	if err != nil {
 		log.Sugar().Fatalf("error creating provider settings table: %v", err)
+	}
+
+	err = store.AlterProviderSettingsTable()
+	if err != nil {
+		log.Sugar().Fatalf("error altering provider settings table: %v", err)
 	}
 
 	memStore, err := memdb.NewMemDb(store, log, cfg.InMemoryDbUpdateInterval)

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -8,12 +8,6 @@ import (
 	internal_errors "github.com/bricks-cloud/bricksllm/internal/errors"
 )
 
-type Provider string
-
-const (
-	OpenAiProvider Provider = "openai"
-)
-
 type UpdateKey struct {
 	Name                   string   `json:"name"`
 	UpdatedAt              int64    `json:"updatedAt"`

--- a/internal/logger/zap/zap.go
+++ b/internal/logger/zap/zap.go
@@ -136,7 +136,7 @@ func NewZapLogger(mode string) *zap.Logger {
 	}
 
 	if mode == "production" {
-		cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
+		// cfg.Level = zap.NewAtomicLevelAt(zapcore.InfoLevel)
 		return zap.Must(cfg.Build())
 	}
 

--- a/internal/provider/setting.go
+++ b/internal/provider/setting.go
@@ -4,6 +4,7 @@ type Setting struct {
 	CreatedAt int64             `json:"createdAt"`
 	UpdatedAt int64             `json:"updatedAt"`
 	Provider  string            `json:"provider"`
-	Setting   map[string]string `json:"setting"`
+	Setting   map[string]string `json:"setting,omitempty"`
 	Id        string            `json:"id"`
+	Name      string            `json:"name"`
 }


### PR DESCRIPTION
## Context
- Provider setting does not have a human readable name
- Metrics endpoints stopped working due to postgeSQL schema inconsistencies

## Tasks
- [x] Start supporting name field in provider settings
- [x] Add DB migration at application start 
