### PR TITLE
[V1.2.1] Fix update provider setting endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.1 - 2023-11-27
+### Changed
+- Remove support for changing provider when updating provider setting
+
+### Fixed
+- Fixed issues with not being able to update provider setting name
+
 ## 1.2.0 - 2023-11-21
 ### Added
 - Added new filters tags and provider to getting keys API 

--- a/README.md
+++ b/README.md
@@ -377,7 +377,6 @@ This endpoint is updating a provider setting .
 ##### Request
 > | Field | type | type | example                      | description |
 > |---------------|-----------------------------------|-|-|-|
-> | provider | required | `enum` | openai | This value can only be `openai` as for now. |
 > | setting | required | `object` | `{ "apikey": "YOUR_OPENAI_KEY" }`            | A map of values used for authenticating with the selected provider. |
 > | setting.apikey | required | `string` | xx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx | This field is required if `provider` is `openai`. |
 > | name | optional | `string` | YOUR_PROVIDER_SETTING_NAME | This field is used for giving a name to provider setting |

--- a/internal/manager/provider_setting.go
+++ b/internal/manager/provider_setting.go
@@ -64,8 +64,15 @@ func (m *ProviderSettingsManager) UpdateSetting(id string, setting *provider.Set
 		return nil, internal_errors.NewValidationError("id cannot be empty")
 	}
 
-	if len(setting.Setting) == 0 {
-		return nil, internal_errors.NewValidationError("settings field cannot be empty")
+	existing, _ := m.Storage.GetProviderSetting(id)
+	if existing == nil {
+		return nil, internal_errors.NewNotFoundError("provider setting is not found")
+	}
+
+	if len(setting.Setting) != 0 && existing.Provider == "openai" {
+		if val, _ := setting.Setting["apikey"]; len(val) == 0 {
+			return nil, internal_errors.NewValidationError("api key cannot be empty when the provider is openai")
+		}
 	}
 
 	setting.UpdatedAt = time.Now().Unix()

--- a/internal/testing/provider_setting_integration_test.go
+++ b/internal/testing/provider_setting_integration_test.go
@@ -89,6 +89,41 @@ func getProviderSettings() ([]*provider.Setting, error) {
 	return settings, nil
 }
 
+func updateProviderSetting(id string, setting *provider.Setting) (*provider.Setting, error) {
+	jsonData, err := json.Marshal(setting)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(&http.Request{
+		Method: http.MethodPatch,
+		URL:    &url.URL{Scheme: "http", Host: "localhost:8001", Path: "/api/provider-settings/" + id},
+		Body:   io.NopCloser(bytes.NewBuffer(jsonData)),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var updated *provider.Setting
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(string(data))
+	}
+
+	if err := json.Unmarshal(data, &updated); err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
 func TestProviderSetting_Creation(t *testing.T) {
 	db := connectToPostgreSqlDb()
 	t.Run("when a provider setting gets created", func(t *testing.T) {
@@ -103,13 +138,14 @@ func TestProviderSetting_Creation(t *testing.T) {
 		created, err := createProviderSetting(setting)
 		require.Nil(t, err)
 
+		defer deleteProviderSetting(db, created.Id)
+
 		assert.Equal(t, setting.Name, created.Name)
 		assert.Equal(t, setting.Provider, created.Provider)
 		assert.Nil(t, created.Setting)
 		assert.NotEmpty(t, created.CreatedAt)
 		assert.NotEmpty(t, created.UpdatedAt)
 		assert.NotEmpty(t, created.Id)
-		deleteProviderSetting(db, created.Id)
 	})
 }
 
@@ -156,5 +192,86 @@ func TestProviderSetting_Retrieval(t *testing.T) {
 			deleteProviderSetting(db, setting.Id)
 		}
 
+	})
+}
+
+func TestProviderSetting_Update(t *testing.T) {
+	db := connectToPostgreSqlDb()
+	t.Run("when updating provider settings name", func(t *testing.T) {
+		setting := &provider.Setting{
+			Provider: "openai",
+			Setting: map[string]string{
+				"apikey": "secret-key",
+			},
+			Name: "test",
+		}
+
+		updates := &provider.Setting{
+			Name: "test-1",
+		}
+
+		created, err := createProviderSetting(setting)
+		require.Nil(t, err)
+
+		defer deleteProviderSetting(db, created.Id)
+
+		updated, err := updateProviderSetting(created.Id, updates)
+		require.Nil(t, err)
+
+		assert.Equal(t, updates.Name, updated.Name)
+		assert.NotEqual(t, created.UpdatedAt, updates.UpdatedAt)
+	})
+
+	t.Run("when updating provider settings with incorret settings", func(t *testing.T) {
+		setting := &provider.Setting{
+			Provider: "openai",
+			Setting: map[string]string{
+				"apikey": "secret-key",
+			},
+			Name: "test",
+		}
+
+		updates := &provider.Setting{
+			Setting: map[string]string{
+				"api": "secret-key",
+			},
+			Name: "test-1",
+		}
+
+		created, err := createProviderSetting(setting)
+		require.Nil(t, err)
+
+		defer deleteProviderSetting(db, created.Id)
+
+		_, err = updateProviderSetting(created.Id, updates)
+		assert.Error(t, err)
+	})
+
+	t.Run("when updating provider settings name and setting", func(t *testing.T) {
+		setting := &provider.Setting{
+			Provider: "openai",
+			Setting: map[string]string{
+				"apikey": "secret-key",
+			},
+			Name: "test",
+		}
+
+		updates := &provider.Setting{
+			Setting: map[string]string{
+				"apikey": "secret-key-1",
+			},
+			Name: "test-1",
+		}
+
+		created, err := createProviderSetting(setting)
+		require.Nil(t, err)
+
+		defer deleteProviderSetting(db, created.Id)
+
+		updated, err := updateProviderSetting(created.Id, updates)
+		require.NoError(t, err)
+
+		assert.Equal(t, updates.Name, updated.Name)
+		assert.NotEqual(t, created.UpdatedAt, updates.UpdatedAt)
 	})
 }


### PR DESCRIPTION
## Context
- Update provider setting endpoint does not allow updates for name field
- Update provider setting endpoint does not validate whether settings are valid


## Tasks
- [x] Fixed not being able to update name field for update provider setting endpoint
- [x] Added validation for settings for update provider setting endpoint
- [x] Added more integration tests for update provider setting endpoint