### PR TITLE
[V1.10.0] Added request, response and userId to event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.10.0 - 2024-02-21
+### Added
+- Added `userId` as a new filter option for get events API endpoint
+- Added option to store request and response using keys
+
 ## 1.9.6 - 2024-02-18
 ### Added
 - Added support for updating key cost limit and rate limit

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -15,4 +15,7 @@ type Event struct {
 	Path                 string   `json:"path"`
 	Method               string   `json:"method"`
 	CustomId             string   `json:"custom_id"`
+	Request              []byte   `json:"request"`
+	Response             []byte   `json:"response"`
+	UserId               string   `json:"userId"`
 }

--- a/internal/event/reporting.go
+++ b/internal/event/reporting.go
@@ -11,6 +11,7 @@ type DataPoint struct {
 	Model                string  `json:"model"`
 	KeyId                string  `json:"keyId"`
 	CustomId             string  `json:"customId"`
+	UserId               string  `json:"userId"`
 }
 
 type ReportingResponse struct {
@@ -23,6 +24,7 @@ type ReportingRequest struct {
 	KeyIds    []string `json:"keyIds"`
 	Tags      []string `json:"tags"`
 	CustomIds []string `json:"customIds"`
+	UserIds   []string `json:"userIds"`
 	Start     int64    `json:"start"`
 	End       int64    `json:"end"`
 	Increment int64    `json:"increment"`

--- a/internal/key/key.go
+++ b/internal/key/key.go
@@ -25,6 +25,8 @@ type UpdateKey struct {
 	RateLimitOverTime      int           `json:"rateLimitOverTime"`
 	RateLimitUnit          TimeUnit      `json:"rateLimitUnit"`
 	AllowedPaths           *[]PathConfig `json:"allowedPaths,omitempty"`
+	ShouldLogRequest       *bool         `json:"shouldLogRequest"`
+	ShouldLogResponse      *bool         `json:"shouldLogResponse"`
 }
 
 func (uk *UpdateKey) Validate() error {
@@ -127,6 +129,8 @@ type RequestKey struct {
 	SettingId              string       `json:"settingId"`
 	AllowedPaths           []PathConfig `json:"allowedPaths"`
 	SettingIds             []string     `json:"settingIds"`
+	ShouldLogRequest       bool         `json:"shouldLogRequest"`
+	ShouldLogResponse      bool         `json:"shouldLogResponse"`
 }
 
 func (rk *RequestKey) Validate() error {
@@ -271,6 +275,8 @@ type ResponseKey struct {
 	SettingId              string       `json:"settingId"`
 	AllowedPaths           []PathConfig `json:"allowedPaths"`
 	SettingIds             []string     `json:"settingIds"`
+	ShouldLogRequest       bool         `json:"shouldLogRequest"`
+	ShouldLogResponse      bool         `json:"shouldLogResponse"`
 }
 
 func (rk *ResponseKey) GetSettingIds() []string {

--- a/internal/manager/reporting.go
+++ b/internal/manager/reporting.go
@@ -16,7 +16,7 @@ type keyStorage interface {
 
 type eventStorage interface {
 	GetEvents(userId, customId string, keyIds []string, start, end int64) ([]*event.Event, error)
-	GetEventDataPoints(start, end, increment int64, tags, keyIds, customIds []string, filters []string) ([]*event.DataPoint, error)
+	GetEventDataPoints(start, end, increment int64, tags, keyIds, customIds, userIds []string, filters []string) ([]*event.DataPoint, error)
 	GetLatencyPercentiles(start, end int64, tags, keyIds []string) ([]float64, error)
 }
 
@@ -35,7 +35,7 @@ func NewReportingManager(cs costStorage, ks keyStorage, es eventStorage) *Report
 }
 
 func (rm *ReportingManager) GetEventReporting(e *event.ReportingRequest) (*event.ReportingResponse, error) {
-	dataPoints, err := rm.es.GetEventDataPoints(e.Start, e.End, e.Increment, e.Tags, e.KeyIds, e.CustomIds, e.Filters)
+	dataPoints, err := rm.es.GetEventDataPoints(e.Start, e.End, e.Increment, e.Tags, e.KeyIds, e.CustomIds, e.UserIds, e.Filters)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/manager/reporting.go
+++ b/internal/manager/reporting.go
@@ -15,7 +15,7 @@ type keyStorage interface {
 }
 
 type eventStorage interface {
-	GetEvents(customId string, keyIds []string, start, end int64) ([]*event.Event, error)
+	GetEvents(userId, customId string, keyIds []string, start, end int64) ([]*event.Event, error)
 	GetEventDataPoints(start, end, increment int64, tags, keyIds, customIds []string, filters []string) ([]*event.DataPoint, error)
 	GetLatencyPercentiles(start, end int64, tags, keyIds []string) ([]float64, error)
 }
@@ -77,8 +77,8 @@ func (rm *ReportingManager) GetKeyReporting(keyId string) (*key.KeyReporting, er
 	}, err
 }
 
-func (rm *ReportingManager) GetEvents(customId string, keyIds []string, start, end int64) ([]*event.Event, error) {
-	events, err := rm.es.GetEvents(customId, keyIds, start, end)
+func (rm *ReportingManager) GetEvents(userId, customId string, keyIds []string, start, end int64) ([]*event.Event, error) {
+	events, err := rm.es.GetEvents(userId, customId, keyIds, start, end)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/message/handler.go
+++ b/internal/message/handler.go
@@ -248,7 +248,7 @@ func (h *Handler) HandleEventWithRequestAndResponse(m Message) error {
 	start := time.Now()
 	err := h.recorder.RecordEvent(e.Event)
 	if err != nil {
-		h.log.Debug("error when recording event", zap.Error(err))
+		h.log.Debug("error when recording an event", zap.Error(err))
 		stats.Incr("bricksllm.message.handler.handle_event_with_request_and_response.record_event_error", nil, 1)
 		return err
 	}

--- a/internal/message/handler.go
+++ b/internal/message/handler.go
@@ -99,7 +99,7 @@ func (h *Handler) HandleEvent(m Message) error {
 	err := h.recorder.RecordEvent(e)
 	if err != nil {
 		stats.Incr("bricksllm.message.handler.handle_event.record_event_error", nil, 1)
-		h.log.Sugar().Debugf("error when publishin event: %v", err)
+		h.log.Sugar().Debugf("error when publish in event: %v", err)
 		return err
 	}
 
@@ -243,12 +243,12 @@ func (h *Handler) HandleEventWithRequestAndResponse(m Message) error {
 			stats.Incr("bricksllm.message.handler.handle_event_with_request_and_response.handle_validation_result_error", nil, 1)
 			h.log.Debug("error when handling validation result", zap.Error(err))
 		}
-
 	}
 
 	start := time.Now()
 	err := h.recorder.RecordEvent(e.Event)
 	if err != nil {
+		h.log.Debug("error when recording event", zap.Error(err))
 		stats.Incr("bricksllm.message.handler.handle_event_with_request_and_response.record_event_error", nil, 1)
 		return err
 	}

--- a/internal/storage/postgresql/postgresql.go
+++ b/internal/storage/postgresql/postgresql.go
@@ -101,7 +101,7 @@ func (s *Store) AlterKeysTable() error {
 			END IF;
 		END
 		$$;
-		ALTER TABLE keys ADD COLUMN IF NOT EXISTS setting_id VARCHAR(255), ADD COLUMN IF NOT EXISTS allowed_paths JSONB, ADD COLUMN IF NOT EXISTS setting_ids VARCHAR(255)[] NOT NULL DEFAULT ARRAY[]::VARCHAR(255)[];
+		ALTER TABLE keys ADD COLUMN IF NOT EXISTS setting_id VARCHAR(255), ADD COLUMN IF NOT EXISTS allowed_paths JSONB, ADD COLUMN IF NOT EXISTS setting_ids VARCHAR(255)[] NOT NULL DEFAULT ARRAY[]::VARCHAR(255)[], ADD COLUMN IF NOT EXISTS should_log_request BOOLEAN NOT NULL DEFAULT FALSE, ADD COLUMN IF NOT EXISTS should_log_response BOOLEAN NOT NULL DEFAULT FALSE;
 	`
 
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), s.wt)
@@ -142,7 +142,7 @@ func (s *Store) CreateEventsTable() error {
 
 func (s *Store) AlterEventsTable() error {
 	alterTableQuery := `
-		ALTER TABLE events ADD COLUMN IF NOT EXISTS path VARCHAR(255), ADD COLUMN IF NOT EXISTS method VARCHAR(255), ADD COLUMN IF NOT EXISTS custom_id VARCHAR(255)
+		ALTER TABLE events ADD COLUMN IF NOT EXISTS path VARCHAR(255), ADD COLUMN IF NOT EXISTS method VARCHAR(255), ADD COLUMN IF NOT EXISTS custom_id VARCHAR(255), ADD COLUMN IF NOT EXISTS request JSONB, ADD COLUMN IF NOT EXISTS response JSONB, ADD COLUMN IF NOT EXISTS user_id VARCHAR(255) NOT NULL DEFAULT '';
 	`
 
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), s.wt)
@@ -211,8 +211,8 @@ func (s *Store) DropKeysTable() error {
 
 func (s *Store) InsertEvent(e *event.Event) error {
 	query := `
-		INSERT INTO events (event_id, created_at, tags, key_id, cost_in_usd, provider, model, status_code, prompt_token_count, completion_token_count, latency_in_ms, path, method, custom_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+		INSERT INTO events (event_id, created_at, tags, key_id, cost_in_usd, provider, model, status_code, prompt_token_count, completion_token_count, latency_in_ms, path, method, custom_id, request, response, user_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 	`
 
 	values := []any{
@@ -230,6 +230,9 @@ func (s *Store) InsertEvent(e *event.Event) error {
 		e.Path,
 		e.Method,
 		e.CustomId,
+		e.Request,
+		e.Response,
+		e.UserId,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), s.wt)
@@ -241,12 +244,30 @@ func (s *Store) InsertEvent(e *event.Event) error {
 	return nil
 }
 
-func (s *Store) GetEvents(customId string, keyIds []string, start int64, end int64) ([]*event.Event, error) {
-	if len(customId) == 0 && len(keyIds) == 0 {
-		return nil, errors.New("neither customId nor keyIds are specified")
+func shouldAddAnd(userId, customId string, keyIds []string) bool {
+	num := 0
+
+	if len(userId) == 0 {
+		num++
 	}
 
-	if len(keyIds) == 0 && (start == 0 || end == 0) {
+	if len(customId) == 0 {
+		num++
+	}
+
+	if len(keyIds) == 0 {
+		num++
+	}
+
+	return num >= 2
+}
+
+func (s *Store) GetEvents(userId string, customId string, keyIds []string, start int64, end int64) ([]*event.Event, error) {
+	if len(customId) == 0 && len(keyIds) == 0 && len(userId) == 0 {
+		return nil, errors.New("none of customId, keyIds and userId is specified")
+	}
+
+	if len(keyIds) != 0 && (start == 0 || end == 0) {
 		return nil, errors.New("keyIds are provided but either start or end is not specified")
 	}
 
@@ -258,7 +279,15 @@ func (s *Store) GetEvents(customId string, keyIds []string, start int64, end int
 		query += fmt.Sprintf(" custom_id = '%s'", customId)
 	}
 
-	if len(customId) != 0 && len(keyIds) != 0 {
+	if len(customId) > 0 && len(userId) > 0 {
+		query += " AND"
+	}
+
+	if len(userId) != 0 {
+		query += fmt.Sprintf(" user_id = '%s'", userId)
+	}
+
+	if (len(customId) > 0 || len(userId) > 0) && len(keyIds) > 0 {
 		query += " AND"
 	}
 
@@ -300,6 +329,9 @@ func (s *Store) GetEvents(customId string, keyIds []string, start int64, end int
 			&path,
 			&method,
 			&customId,
+			&e.Request,
+			&e.Response,
+			&e.UserId,
 		); err != nil {
 			return nil, err
 		}
@@ -583,6 +615,8 @@ func (s *Store) GetKeys(tags, keyIds []string, provider string) ([]*key.Response
 			&settingId,
 			&data,
 			pq.Array(&k.SettingIds),
+			&k.ShouldLogRequest,
+			&k.ShouldLogResponse,
 		); err != nil {
 			return nil, err
 		}
@@ -639,6 +673,8 @@ func (s *Store) GetKey(keyId string) (*key.ResponseKey, error) {
 			&settingId,
 			&data,
 			pq.Array(&k.SettingIds),
+			&k.ShouldLogRequest,
+			&k.ShouldLogResponse,
 		); err != nil {
 			return nil, err
 		}
@@ -780,6 +816,8 @@ func (s *Store) GetAllKeys() ([]*key.ResponseKey, error) {
 			&settingId,
 			&data,
 			pq.Array(&k.SettingIds),
+			&k.ShouldLogRequest,
+			&k.ShouldLogResponse,
 		); err != nil {
 			return nil, err
 		}
@@ -874,6 +912,8 @@ func (s *Store) GetUpdatedKeys(updatedAt int64) ([]*key.ResponseKey, error) {
 			&settingId,
 			&data,
 			pq.Array(&k.SettingIds),
+			&k.ShouldLogRequest,
+			&k.ShouldLogResponse,
 		); err != nil {
 			return nil, err
 		}
@@ -1021,6 +1061,18 @@ func (s *Store) UpdateKey(id string, uk *key.UpdateKey) (*key.ResponseKey, error
 		counter++
 	}
 
+	if uk.ShouldLogRequest != nil {
+		values = append(values, *uk.ShouldLogRequest)
+		fields = append(fields, fmt.Sprintf("should_log_request = $%d", counter))
+		counter++
+	}
+
+	if uk.ShouldLogResponse != nil {
+		values = append(values, *uk.ShouldLogResponse)
+		fields = append(fields, fmt.Sprintf("should_log_response = $%d", counter))
+		counter++
+	}
+
 	if uk.AllowedPaths != nil {
 		data, err := json.Marshal(uk.AllowedPaths)
 		if err != nil {
@@ -1057,6 +1109,8 @@ func (s *Store) UpdateKey(id string, uk *key.UpdateKey) (*key.ResponseKey, error
 		&settingId,
 		&data,
 		pq.Array(&k.SettingIds),
+		&k.ShouldLogRequest,
+		&k.ShouldLogResponse,
 	); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, internal_errors.NewNotFoundError(fmt.Sprintf("key not found for id: %s", id))
@@ -1196,8 +1250,8 @@ func (s *Store) CreateProviderSetting(setting *provider.Setting) (*provider.Sett
 
 func (s *Store) CreateKey(rk *key.RequestKey) (*key.ResponseKey, error) {
 	query := `
-		INSERT INTO keys (name, created_at, updated_at, tags, revoked, key_id, key, revoked_reason, cost_limit_in_usd, cost_limit_in_usd_over_time, cost_limit_in_usd_unit, rate_limit_over_time, rate_limit_unit, ttl, setting_id, allowed_paths, setting_ids)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+		INSERT INTO keys (name, created_at, updated_at, tags, revoked, key_id, key, revoked_reason, cost_limit_in_usd, cost_limit_in_usd_over_time, cost_limit_in_usd_unit, rate_limit_over_time, rate_limit_unit, ttl, setting_id, allowed_paths, setting_ids, should_log_request, should_log_response)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		RETURNING *;
 	`
 
@@ -1224,6 +1278,8 @@ func (s *Store) CreateKey(rk *key.RequestKey) (*key.ResponseKey, error) {
 		rk.SettingId,
 		rdata,
 		sliceToSqlStringArray(rk.SettingIds),
+		rk.ShouldLogRequest,
+		rk.ShouldLogResponse,
 	}
 
 	ctxTimeout, cancel := context.WithTimeout(context.Background(), s.wt)
@@ -1251,6 +1307,8 @@ func (s *Store) CreateKey(rk *key.RequestKey) (*key.ResponseKey, error) {
 		&settingId,
 		&data,
 		pq.Array(&k.SettingIds),
+		&k.ShouldLogRequest,
+		&k.ShouldLogResponse,
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Context
- Users might want to see request and response
- Users want to query data points and events using userId

## Tasks
- [x] Added new fields to key that control whether or not to store request and responses in events
- [x] Started tracking `userId` in events
- [x] Added `userId` as a querying option for events and data points