### PR TITLE
copy query params when forwarding requests

### DIFF
--- a/internal/server/web/proxy/proxy.go
+++ b/internal/server/web/proxy/proxy.go
@@ -282,6 +282,9 @@ func getPassThroughHandler(prod, private bool, client http.Client, log *zap.Logg
 			return
 		}
 
+		// copy query params
+		req.URL.RawQuery = c.Request.URL.RawQuery
+
 		copyHttpHeaders(c.Request, req)
 
 		if c.FullPath() == "/api/providers/openai/v1/files" && c.Request.Method == http.MethodPost {


### PR DESCRIPTION
Some endpoints are not behaving properly because we currently don't copy query params when forwarding requests.

For example, GET /threads/{thread_id}/messages (doc) takes in query params for pagination.

Added a line to copy query params before making the request.