### PR TITLE
Store redact action

### DIFF
--- a/internal/errors/redact_err.go
+++ b/internal/errors/redact_err.go
@@ -1,0 +1,17 @@
+package errors
+
+type RedactError struct {
+	message string
+}
+
+func NewRedactError(msg string) *RedactError {
+	return &RedactError{
+		message: msg,
+	}
+}
+
+func (we *RedactError) Error() string {
+	return we.message
+}
+
+func (we *RedactError) Redacted() {}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -118,7 +118,7 @@ func (r *EventRequest) Validate() error {
 	}
 
 	for _, a := range r.Actions {
-		if a != "warned" && a != "allowed" && a != "blocked" {
+		if a != "warned" && a != "allowed" && a != "blocked" && a != "redacted" {
 			return internal_errors.NewValidationError(fmt.Sprintf("action cannot be %s", a))
 		}
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -241,12 +241,12 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
-			if result.Action == AllowButRedact {
-				return internal_errors.NewRedactError("request redacted due to detected entities")
-			}
-
 			if len(result.Updated) == 1 {
 				converted.Input = result.Updated[0]
+			}
+
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
 			}
 		} else if input, ok := converted.Input.(string); ok {
 			result, err := p.scan([]string{input}, scanner, cd, log)
@@ -262,12 +262,12 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
-			if result.Action == AllowButRedact {
-				return internal_errors.NewRedactError("request redacted due to detected entities")
-			}
-
 			if len(result.Updated) == 1 {
 				converted.Input = result.Updated[0]
+			}
+
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
 			}
 		}
 
@@ -294,10 +294,6 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 		}
 
-		if result.Action == AllowButRedact {
-			return internal_errors.NewRedactError("request redacted due to detected entities")
-		}
-
 		if len(result.Updated) != len(converted.Messages) {
 			return errors.New("updated contents length not consistent with existing content length")
 		}
@@ -314,6 +310,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 		}
 
 		converted.Messages = newMessages
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
+		}
 
 		return nil
 	case *vllm.CompletionRequest:
@@ -332,12 +332,12 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
-			if result.Action == AllowButRedact {
-				return internal_errors.NewRedactError("request redacted due to detected entities")
-			}
-
 			if len(result.Updated) == 1 {
 				converted.Prompt = result.Updated[0]
+			}
+
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
 			}
 
 		} else if input, ok := converted.Prompt.(string); ok {
@@ -354,13 +354,12 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
-			if result.Action == AllowButRedact {
-				return internal_errors.NewRedactError("request redacted due to detected entities")
-			}
-
-			// Book mark
 			if len(result.Updated) == 1 {
 				converted.Prompt = result.Updated[0]
+			}
+
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
 			}
 		}
 
@@ -387,10 +386,6 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 		}
 
-		if result.Action == AllowButRedact {
-			return internal_errors.NewRedactError("request redacted due to detected entities")
-		}
-
 		if len(result.Updated) != len(converted.Messages) {
 			return errors.New("updated contents length not consistent with existing content length")
 		}
@@ -407,6 +402,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 		}
 
 		converted.Messages = newMessages
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
+		}
 
 		return nil
 
@@ -432,10 +431,6 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 		}
 
-		if result.Action == AllowButRedact {
-			return internal_errors.NewRedactError("request redacted due to detected entities")
-		}
-
 		if len(result.Updated) != len(converted.Messages) {
 			return errors.New("updated contents length not consistent with existing content length")
 		}
@@ -448,6 +443,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 		}
 
 		converted.Messages = newMessages
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
+		}
 
 		return nil
 
@@ -466,12 +465,12 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 		}
 
-		if result.Action == AllowButRedact {
-			return internal_errors.NewRedactError("request redacted due to detected entities")
-		}
-
 		if len(result.Updated) == 1 {
 			converted.Prompt = result.Updated[0]
+		}
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
 		}
 
 		return nil

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -241,6 +241,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
+			}
+
 			if len(result.Updated) == 1 {
 				converted.Input = result.Updated[0]
 			}
@@ -256,6 +260,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 
 			if result.Action == AllowButWarn {
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
+			}
+
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
 			}
 
 			if len(result.Updated) == 1 {
@@ -284,6 +292,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 
 		if result.Action == AllowButWarn {
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
+		}
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
 		}
 
 		if len(result.Updated) != len(converted.Messages) {
@@ -320,6 +332,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
+			}
+
 			if len(result.Updated) == 1 {
 				converted.Prompt = result.Updated[0]
 			}
@@ -338,6 +354,11 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 				return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 			}
 
+			if result.Action == AllowButRedact {
+				return internal_errors.NewRedactError("request redacted due to detected entities")
+			}
+
+			// Book mark
 			if len(result.Updated) == 1 {
 				converted.Prompt = result.Updated[0]
 			}
@@ -364,6 +385,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 
 		if result.Action == AllowButWarn {
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
+		}
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
 		}
 
 		if len(result.Updated) != len(converted.Messages) {
@@ -407,6 +432,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
 		}
 
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
+		}
+
 		if len(result.Updated) != len(converted.Messages) {
 			return errors.New("updated contents length not consistent with existing content length")
 		}
@@ -435,6 +464,10 @@ func (p *Policy) Filter(client http.Client, input any, scanner Scanner, cd Custo
 
 		if result.Action == AllowButWarn {
 			return internal_errors.NewWarningError("request warned due to detected entities: " + join(result.WarnedEntities, result.WarnedRegexDefinitions, []string{}))
+		}
+
+		if result.Action == AllowButRedact {
+			return internal_errors.NewRedactError("request redacted due to detected entities")
 		}
 
 		if len(result.Updated) == 1 {
@@ -605,6 +638,7 @@ func (p *Policy) scan(input []string, scanner Scanner, cd CustomPolicyDetector, 
 
 						old := detection.Input[entity.BeginOffset:entity.EndOffset]
 						replaced = strings.ReplaceAll(replaced, old, "***")
+						fmt.Println("-----redacted with aws:" + replaced)
 					}
 				}
 
@@ -717,6 +751,7 @@ func (p *Policy) scan(input []string, scanner Scanner, cd CustomPolicyDetector, 
 					}
 
 					replaced = regex.ReplaceAllString(text, "***")
+					fmt.Println("-----redacted with regex:" + replaced)
 				}
 			}
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -637,7 +637,6 @@ func (p *Policy) scan(input []string, scanner Scanner, cd CustomPolicyDetector, 
 
 						old := detection.Input[entity.BeginOffset:entity.EndOffset]
 						replaced = strings.ReplaceAll(replaced, old, "***")
-						fmt.Println("-----redacted with aws:" + replaced)
 					}
 				}
 
@@ -750,7 +749,6 @@ func (p *Policy) scan(input []string, scanner Scanner, cd CustomPolicyDetector, 
 					}
 
 					replaced = regex.ReplaceAllString(text, "***")
-					fmt.Println("-----redacted with regex:" + replaced)
 				}
 			}
 

--- a/internal/server/web/proxy/middleware.go
+++ b/internal/server/web/proxy/middleware.go
@@ -111,6 +111,11 @@ type warnedError interface {
 	Warnings()
 }
 
+type redactedError interface {
+	Error() string
+	Redacted()
+}
+
 type publisher interface {
 	Publish(message.Message)
 }
@@ -1033,6 +1038,11 @@ func getMiddleware(cpm CustomProvidersManager, rm routeManager, pm PoliciesManag
 				_, ok = err.(warnedError)
 				if ok {
 					c.Set("action", "warned")
+				}
+
+				_, ok = err.(redactedError)
+				if ok {
+					c.Set("action", "redacted")
 				}
 
 				logError(log, "error when filtering a request", prod, cid, err)


### PR DESCRIPTION
Currently both allowed and redacted events are stored as `allowed`. This PR introduces change to store `redacted` as a separate action type. 