### PR TITLE
Do not run policy if policyInput is not assigned a value

### DIFF
--- a/internal/server/web/proxy/middleware.go
+++ b/internal/server/web/proxy/middleware.go
@@ -1019,7 +1019,7 @@ func getMiddleware(cpm CustomProvidersManager, rm routeManager, pm PoliciesManag
 			}
 		}
 
-		if p != nil {
+		if p != nil && policyInput != nil {
 			err := p.Filter(client, policyInput, scanner, cd, log)
 			if err == nil {
 				c.Set("action", "allowed")


### PR DESCRIPTION
# Issue
When using a secret key with a policy to make a request to `POST /api/providers/openai/v1/assistants`, OpenAI returns this error:
```
{'error': {'message': "Missing required parameter: 'assistant_id'.", 'type': 'invalid_request_error', 'param': 'assistant_id', 'code': 'missing_required_parameter'}}
```

This is because when a `p` exists but `policyInput` is `nil`, `json.Marshal` fails and the request body does not get reset. Hence we're forwarding an empty request body to OpenAI, causing OpenAI to return an error.

# Fix
Fix is to add a check to see if policyInput exists before running `p.Filter`.