### PR TITLE
both proxy and admin log do not need pass in correlation id explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 release_notes.md
 target
 .DS_STORE
+.vscode/launch.json

--- a/internal/server/web/admin/event.go
+++ b/internal/server/web/admin/event.go
@@ -5,12 +5,13 @@ import (
 	"time"
 
 	"github.com/bricks-cloud/bricksllm/internal/stats"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 )
 
-func getGetUserIdsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetUserIdsHandler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_user_ids_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -43,12 +44,11 @@ func getGetUserIdsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		cids, err := m.GetUserIds(kid)
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_user_ids_handler.get_user_ids_err", nil, 1)
 
-			logError(log, "error when getting userIds", prod, cid, err)
+			logError(log, "error when getting userIds", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/key-reporting-manager",
 				Title:    "getting user ids error",
@@ -64,8 +64,9 @@ func getGetUserIdsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin
 	}
 }
 
-func getGetCustomIdsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetCustomIdsHandler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_custom_ids_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -99,13 +100,11 @@ func getGetCustomIdsHandler(m KeyReportingManager, log *zap.Logger, prod bool) g
 			return
 		}
 
-		cid := c.GetString(correlationId)
-
 		cids, err := m.GetCustomIds(kid)
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_user_ids_handler.get_custom_ids_err", nil, 1)
 
-			logError(log, "error when getting custom ids", prod, cid, err)
+			logError(log, "error when getting custom ids", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/key-reporting-manager",
 				Title:    "getting custom ids error",

--- a/internal/server/web/admin/events.go
+++ b/internal/server/web/admin/events.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/bricks-cloud/bricksllm/internal/event"
 	"github.com/bricks-cloud/bricksllm/internal/stats"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 )
 
-func getGetEventsV2Handler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetEventsV2Handler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_events_v2_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -34,10 +35,9 @@ func getGetEventsV2Handler(m KeyReportingManager, log *zap.Logger, prod bool) gi
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading get events request body", prod, cid, err)
+			logError(log, "error when reading get events request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "get events request body reader error",
@@ -51,7 +51,7 @@ func getGetEventsV2Handler(m KeyReportingManager, log *zap.Logger, prod bool) gi
 		request := &event.EventRequest{}
 		err = json.Unmarshal(data, request)
 		if err != nil {
-			logError(log, "error when unmarshalling get events request body", prod, cid, err)
+			logError(log, "error when unmarshalling get events request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -84,7 +84,7 @@ func getGetEventsV2Handler(m KeyReportingManager, log *zap.Logger, prod bool) gi
 				return
 			}
 
-			logError(log, "error when getting events", prod, cid, err)
+			logError(log, "error when getting events", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/event-manager",
 				Title:    "getting events errored out",

--- a/internal/server/web/admin/policy.go
+++ b/internal/server/web/admin/policy.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/bricks-cloud/bricksllm/internal/policy"
 	"github.com/bricks-cloud/bricksllm/internal/stats"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 )
 
-func getCreatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getCreatePolicyHandler(pm PoliciesManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_create_policy_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -34,10 +35,9 @@ func getCreatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading policy creation request body", prod, cid, err)
+			logError(log, "error when reading policy creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -51,7 +51,7 @@ func getCreatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 		p := &policy.Policy{}
 		err = json.Unmarshal(data, p)
 		if err != nil {
-			logError(log, "error when unmarshalling policy creation request body", prod, cid, err)
+			logError(log, "error when unmarshalling policy creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -66,7 +66,7 @@ func getCreatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_create_policy_handler.creat_policy_error", nil, 1)
 
-			logError(log, "error when creating a policy", prod, cid, err)
+			logError(log, "error when creating a policy", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/policies/creation",
 				Title:    "policy creation failed",
@@ -83,8 +83,9 @@ func getCreatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 	}
 }
 
-func getUpdatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getUpdatePolicyHandler(pm PoliciesManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_update_policy_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -118,10 +119,9 @@ func getUpdatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading policy creation request body", prod, cid, err)
+			logError(log, "error when reading policy creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -135,7 +135,7 @@ func getUpdatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 		p := &policy.UpdatePolicy{}
 		err = json.Unmarshal(data, p)
 		if err != nil {
-			logError(log, "error when unmarshalling policy creation request body", prod, cid, err)
+			logError(log, "error when unmarshalling policy creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -150,7 +150,7 @@ func getUpdatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_update_policy_handler.update_policy_error", nil, 1)
 
-			logError(log, "error when updating a policy by id", prod, cid, err)
+			logError(log, "error when updating a policy by id", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/policie/updates",
 				Title:    "update a policy failed",
@@ -167,8 +167,9 @@ func getUpdatePolicyHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.
 	}
 }
 
-func getGetPoliciesByTagsHandler(pm PoliciesManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetPoliciesByTagsHandler(pm PoliciesManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_policies_by_tags_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -202,7 +203,6 @@ func getGetPoliciesByTagsHandler(pm PoliciesManager, log *zap.Logger, prod bool)
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		policies, err := pm.GetPoliciesByTags(c.QueryArray("tags"))
 		if err != nil {
 			errType := "internal"
@@ -213,7 +213,7 @@ func getGetPoliciesByTagsHandler(pm PoliciesManager, log *zap.Logger, prod bool)
 				}, 1)
 			}()
 
-			logError(log, "error when getting policies by tags", prod, cid, err)
+			logError(log, "error when getting policies by tags", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/policies",
 				Title:    "get policies by tags failed",

--- a/internal/server/web/admin/reporting.go
+++ b/internal/server/web/admin/reporting.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/bricks-cloud/bricksllm/internal/event"
 	"github.com/bricks-cloud/bricksllm/internal/stats"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 )
 
 func validateEventReportingRequest(r *event.ReportingRequest) bool {
@@ -49,8 +49,9 @@ func validateTopKeyReportingRequest(r *event.KeyReportingRequest) bool {
 	return true
 }
 
-func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetEventMetricsHandler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_event_metrics.requests", nil, 1)
 
 		start := time.Now()
@@ -72,10 +73,9 @@ func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading event reporting request body", prod, cid, err)
+			logError(log, "error when reading event reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -89,7 +89,7 @@ func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool
 		request := &event.ReportingRequest{}
 		err = json.Unmarshal(data, request)
 		if err != nil {
-			logError(log, "error when unmarshalling event reporting request body", prod, cid, err)
+			logError(log, "error when unmarshalling event reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -104,7 +104,7 @@ func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool
 			stats.Incr("bricksllm.admin.get_get_event_metrics.request_not_valid", nil, 1)
 
 			err = fmt.Errorf("event reporting request %+v is not valid", request)
-			logError(log, "invalid reporting request", prod, cid, err)
+			logError(log, "invalid reporting request", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/invalid-reporting-request",
 				Title:    "invalid reporting request",
@@ -119,7 +119,7 @@ func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_event_metrics.get_event_reporting_error", nil, 1)
 
-			logError(log, "error when getting event reporting", prod, cid, err)
+			logError(log, "error when getting event reporting", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/event-reporting-manager",
 				Title:    "event reporting error",
@@ -136,8 +136,9 @@ func getGetEventMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool
 	}
 }
 
-func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetEventMetricsByDayHandler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_event_metrics_by_day.requests", nil, 1)
 
 		start := time.Now()
@@ -159,10 +160,9 @@ func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading event by day reporting request body", prod, cid, err)
+			logError(log, "error when reading event by day reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -176,7 +176,7 @@ func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod
 		request := &event.ReportingRequest{}
 		err = json.Unmarshal(data, request)
 		if err != nil {
-			logError(log, "error when unmarshalling event by day reporting request body", prod, cid, err)
+			logError(log, "error when unmarshalling event by day reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -191,7 +191,7 @@ func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod
 			stats.Incr("bricksllm.admin.get_get_event_metrics_by_day.request_not_valid", nil, 1)
 
 			err = fmt.Errorf("event reporting request %+v is not valid", request)
-			logError(log, "invalid reporting request", prod, cid, err)
+			logError(log, "invalid reporting request", prod, err)
 			c.JSON(http.StatusBadRequest, &ErrorResponse{
 				Type:     "/errors/invalid-reporting-request",
 				Title:    "invalid reporting request",
@@ -206,7 +206,7 @@ func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_event_metrics_by_day.get_aggregated_event_by_day_reporting", nil, 1)
 
-			logError(log, "error when getting event by day reporting", prod, cid, err)
+			logError(log, "error when getting event by day reporting", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/event-reporting-manager",
 				Title:    "event reporting error",
@@ -223,8 +223,9 @@ func getGetEventMetricsByDayHandler(m KeyReportingManager, log *zap.Logger, prod
 	}
 }
 
-func getGetTopKeysMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetTopKeysMetricsHandler(m KeyReportingManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_top_keys_metrics_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -246,10 +247,9 @@ func getGetTopKeysMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bo
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading top key reporting request body", prod, cid, err)
+			logError(log, "error when reading top key reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -263,7 +263,7 @@ func getGetTopKeysMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bo
 		request := &event.KeyReportingRequest{}
 		err = json.Unmarshal(data, request)
 		if err != nil {
-			logError(log, "error when unmarshalling top key reporting request body", prod, cid, err)
+			logError(log, "error when unmarshalling top key reporting request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -277,7 +277,7 @@ func getGetTopKeysMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bo
 		if !validateTopKeyReportingRequest(request) {
 			stats.Incr("bricksllm.admin.get_get_top_keys_metrics_handler.request_not_valid", nil, 1)
 			err = fmt.Errorf("top key reporting request %+v is not valid", request)
-			logError(log, "invalid reporting request", prod, cid, err)
+			logError(log, "invalid reporting request", prod, err)
 			c.JSON(http.StatusBadRequest, &ErrorResponse{
 				Type:     "/errors/invalid-reporting-request",
 				Title:    "invalid reporting request",
@@ -292,7 +292,7 @@ func getGetTopKeysMetricsHandler(m KeyReportingManager, log *zap.Logger, prod bo
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_top_keys_metrics_handler.get_top_key_reporting", nil, 1)
 
-			logError(log, "error when getting top key reporting", prod, cid, err)
+			logError(log, "error when getting top key reporting", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/event-reporting-manager",
 				Title:    "top key reporting error",

--- a/internal/server/web/admin/user.go
+++ b/internal/server/web/admin/user.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/bricks-cloud/bricksllm/internal/stats"
 	"github.com/bricks-cloud/bricksllm/internal/user"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
-	"go.uber.org/zap"
 )
 
 type UserManager interface {
@@ -20,8 +20,9 @@ type UserManager interface {
 	UpdateUserViaTagsAndUserId(tags []string, uid string, uu *user.UpdateUser) (*user.User, error)
 }
 
-func getGetUsersHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getGetUsersHandler(m UserManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_get_users_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -84,12 +85,11 @@ func getGetUsersHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFu
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		keys, err := m.GetUsers(tags, keyIds, userIds, offset, limit)
 		if err != nil {
 			stats.Incr("bricksllm.admin.get_get_users_handler.get_users_err", nil, 1)
 
-			logError(log, "error when getting api keys by tag", prod, cid, err)
+			logError(log, "error when getting api keys by tag", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/getting-keys",
 				Title:    "getting keys errored out",
@@ -105,8 +105,9 @@ func getGetUsersHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFu
 	}
 }
 
-func getCreateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getCreateUserHandler(m UserManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_create_user_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -127,10 +128,9 @@ func getCreateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 			return
 		}
 
-		id := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading user creation request body", prod, id, err)
+			logError(log, "error when reading user creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -144,7 +144,7 @@ func getCreateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 		u := &user.User{}
 		err = json.Unmarshal(data, u)
 		if err != nil {
-			logError(log, "error when unmarshalling user creation request body", prod, id, err)
+			logError(log, "error when unmarshalling user creation request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -178,7 +178,7 @@ func getCreateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 				return
 			}
 
-			logError(log, "error when creating user", prod, id, err)
+			logError(log, "error when creating user", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/user-manager",
 				Title:    "user creation error",
@@ -195,8 +195,9 @@ func getCreateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 	}
 }
 
-func getUpdateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getUpdateUserHandler(m UserManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_update_user_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -229,10 +230,9 @@ func getUpdateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading update user request body", prod, cid, err)
+			logError(log, "error when reading update user request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -246,7 +246,7 @@ func getUpdateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 		uu := &user.UpdateUser{}
 		err = json.Unmarshal(data, uu)
 		if err != nil {
-			logError(log, "error when unmarshalling update user request body", prod, cid, err)
+			logError(log, "error when unmarshalling update user request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -280,7 +280,7 @@ func getUpdateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 				return
 			}
 
-			logError(log, "error when updating user", prod, cid, err)
+			logError(log, "error when updating user", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/user-manager",
 				Title:    "update user error",
@@ -297,8 +297,9 @@ func getUpdateUserHandler(m UserManager, log *zap.Logger, prod bool) gin.Handler
 	}
 }
 
-func getUpdateUserViaTagsAndUserIdHandler(m UserManager, log *zap.Logger, prod bool) gin.HandlerFunc {
+func getUpdateUserViaTagsAndUserIdHandler(m UserManager, prod bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.admin.get_update_user_via_tags_and_user_id_handler.requests", nil, 1)
 
 		start := time.Now()
@@ -331,10 +332,9 @@ func getUpdateUserViaTagsAndUserIdHandler(m UserManager, log *zap.Logger, prod b
 			return
 		}
 
-		cid := c.GetString(correlationId)
 		data, err := io.ReadAll(c.Request.Body)
 		if err != nil {
-			logError(log, "error when reading update user via tags and user id request body", prod, cid, err)
+			logError(log, "error when reading update user via tags and user id request body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/request-body-read",
 				Title:    "request body reader error",
@@ -348,7 +348,7 @@ func getUpdateUserViaTagsAndUserIdHandler(m UserManager, log *zap.Logger, prod b
 		uu := &user.UpdateUser{}
 		err = json.Unmarshal(data, uu)
 		if err != nil {
-			logError(log, "error when unmarshalling update user via tags and user id body", prod, cid, err)
+			logError(log, "error when unmarshalling update user via tags and user id body", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/json-unmarshal",
 				Title:    "json unmarshaller error",
@@ -382,7 +382,7 @@ func getUpdateUserViaTagsAndUserIdHandler(m UserManager, log *zap.Logger, prod b
 				return
 			}
 
-			logError(log, "error when updating user", prod, cid, err)
+			logError(log, "error when updating user", prod, err)
 			c.JSON(http.StatusInternalServerError, &ErrorResponse{
 				Type:     "/errors/user-manager",
 				Title:    "update user error",

--- a/internal/server/web/proxy/assistant.go
+++ b/internal/server/web/proxy/assistant.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateAssistantRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateAssistantRequest(log *zap.Logger, data []byte, prod, private bool) {
 	ar := &goopenai.AssistantRequest{}
 	err := json.Unmarshal(data, ar)
 	if err != nil {
@@ -18,7 +18,6 @@ func logCreateAssistantRequest(log *zap.Logger, data []byte, prod, private bool,
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", ar.Model),
 			zap.Any("tools", ar.Tools),
 			zap.Any("file_ids", ar.FileIDs),
@@ -35,7 +34,7 @@ func logCreateAssistantRequest(log *zap.Logger, data []byte, prod, private bool,
 	}
 }
 
-func logAssistantResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logAssistantResponse(log *zap.Logger, data []byte, prod, private bool) {
 	a := &goopenai.Assistant{}
 	err := json.Unmarshal(data, a)
 	if err != nil {
@@ -45,8 +44,6 @@ func logAssistantResponse(log *zap.Logger, data []byte, prod, private bool, cid 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-			zap.String("id", cid),
 			zap.String("object", a.Object),
 			zap.Int64("created_at", a.CreatedAt),
 			zap.String("Model", a.Model),
@@ -63,10 +60,9 @@ func logAssistantResponse(log *zap.Logger, data []byte, prod, private bool, cid 
 	}
 }
 
-func logRetrieveAssistantRequest(log *zap.Logger, prod bool, cid, assistantId string) {
+func logRetrieveAssistantRequest(log *zap.Logger, prod bool, assistantId string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", assistantId),
 		}
 
@@ -74,7 +70,7 @@ func logRetrieveAssistantRequest(log *zap.Logger, prod bool, cid, assistantId st
 	}
 }
 
-func logModifyAssistantRequest(log *zap.Logger, data []byte, prod, private bool, cid, assistantId string) {
+func logModifyAssistantRequest(log *zap.Logger, data []byte, prod, private bool, assistantId string) {
 	ar := &goopenai.AssistantRequest{}
 	err := json.Unmarshal(data, ar)
 	if err != nil {
@@ -84,7 +80,6 @@ func logModifyAssistantRequest(log *zap.Logger, data []byte, prod, private bool,
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", assistantId),
 			zap.String("model", ar.Model),
 			zap.Any("tools", ar.Tools),
@@ -102,10 +97,9 @@ func logModifyAssistantRequest(log *zap.Logger, data []byte, prod, private bool,
 	}
 }
 
-func logDeleteAssistantRequest(log *zap.Logger, prod bool, cid, assistantId string) {
+func logDeleteAssistantRequest(log *zap.Logger, prod bool, assistantId string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", assistantId),
 		}
 
@@ -113,7 +107,7 @@ func logDeleteAssistantRequest(log *zap.Logger, prod bool, cid, assistantId stri
 	}
 }
 
-func logDeleteAssistantResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logDeleteAssistantResponse(log *zap.Logger, data []byte, prod bool) {
 	adr := &goopenai.AssistantDeleteResponse{}
 	err := json.Unmarshal(data, adr)
 	if err != nil {
@@ -123,7 +117,6 @@ func logDeleteAssistantResponse(log *zap.Logger, data []byte, prod bool, cid str
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", adr.ID),
 			zap.String("object", adr.Object),
 			zap.Bool("deleted", adr.Deleted),
@@ -133,17 +126,15 @@ func logDeleteAssistantResponse(log *zap.Logger, data []byte, prod bool, cid str
 	}
 }
 
-func logListAssistantsRequest(log *zap.Logger, prod bool, cid string) {
+func logListAssistantsRequest(log *zap.Logger, prod bool) {
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		log.Info("openai list assistants request", fields...)
 	}
 }
 
-func logListAssistantsResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logListAssistantsResponse(log *zap.Logger, data []byte, prod, private bool) {
 	assistants := &goopenai.AssistantsList{}
 	err := json.Unmarshal(data, assistants)
 	if err != nil {
@@ -159,7 +150,6 @@ func logListAssistantsResponse(log *zap.Logger, data []byte, prod, private bool,
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("assistants", assistants.Assistants),
 		}
 

--- a/internal/server/web/proxy/assistant_file.go
+++ b/internal/server/web/proxy/assistant_file.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateAssistantFileRequest(log *zap.Logger, data []byte, prod bool, cid, aid string) {
+func logCreateAssistantFileRequest(log *zap.Logger, data []byte, prod bool, aid string) {
 	afr := &goopenai.AssistantFileRequest{}
 	err := json.Unmarshal(data, afr)
 	if err != nil {
@@ -18,7 +18,6 @@ func logCreateAssistantFileRequest(log *zap.Logger, data []byte, prod bool, cid,
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", aid),
 			zap.String("file_id", afr.FileID),
 		}
@@ -27,7 +26,7 @@ func logCreateAssistantFileRequest(log *zap.Logger, data []byte, prod bool, cid,
 	}
 }
 
-func logAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logAssistantFileResponse(log *zap.Logger, data []byte, prod bool) {
 	af := &goopenai.AssistantFile{}
 	err := json.Unmarshal(data, af)
 	if err != nil {
@@ -37,7 +36,6 @@ func logAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid strin
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", af.AssistantID),
 			zap.String("id", af.ID),
 			zap.String("object", af.Object),
@@ -48,10 +46,9 @@ func logAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid strin
 	}
 }
 
-func logRetrieveAssistantFileRequest(log *zap.Logger, prod bool, cid, fid, aid string) {
+func logRetrieveAssistantFileRequest(log *zap.Logger, prod bool, fid, aid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", aid),
 			zap.String("file_id", fid),
 		}
@@ -60,10 +57,9 @@ func logRetrieveAssistantFileRequest(log *zap.Logger, prod bool, cid, fid, aid s
 	}
 }
 
-func logDeleteAssistantFileRequest(log *zap.Logger, prod bool, cid, fid, aid string) {
+func logDeleteAssistantFileRequest(log *zap.Logger, prod bool, fid, aid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", aid),
 			zap.String("file_id", fid),
 		}
@@ -72,7 +68,7 @@ func logDeleteAssistantFileRequest(log *zap.Logger, prod bool, cid, fid, aid str
 	}
 }
 
-func logDeleteAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logDeleteAssistantFileResponse(log *zap.Logger, data []byte, prod bool) {
 	dr := &goopenai.AssistantDeleteResponse{}
 	err := json.Unmarshal(data, dr)
 	if err != nil {
@@ -82,7 +78,6 @@ func logDeleteAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", dr.ID),
 			zap.String("object", dr.Object),
 			zap.Bool("deleted", dr.Deleted),
@@ -92,10 +87,9 @@ func logDeleteAssistantFileResponse(log *zap.Logger, data []byte, prod bool, cid
 	}
 }
 
-func logListAssistantFilesRequest(log *zap.Logger, prod bool, cid, aid string, params map[string]string) {
+func logListAssistantFilesRequest(log *zap.Logger, prod bool, aid string, params map[string]string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", aid),
 		}
 
@@ -119,7 +113,7 @@ func logListAssistantFilesRequest(log *zap.Logger, prod bool, cid, aid string, p
 	}
 }
 
-func logListAssistantFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logListAssistantFilesResponse(log *zap.Logger, data []byte, prod bool) {
 	files := &goopenai.AssistantFilesList{}
 	err := json.Unmarshal(data, files)
 	if err != nil {
@@ -129,7 +123,6 @@ func logListAssistantFilesResponse(log *zap.Logger, data []byte, prod bool, cid 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("assistant_files", files.AssistantFiles),
 		}
 

--- a/internal/server/web/proxy/completion.go
+++ b/internal/server/web/proxy/completion.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCompletionRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCompletionRequest(log *zap.Logger, data []byte, prod, private bool) {
 	cr := &anthropic.CompletionRequest{}
 	err := json.Unmarshal(data, cr)
 	if err != nil {
@@ -18,7 +18,6 @@ func logCompletionRequest(log *zap.Logger, data []byte, prod, private bool, cid 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", cr.Model),
 			zap.Int("max_tokens_to_sample", cr.MaxTokensToSample),
 			zap.Any("stop_sequnces", cr.StopSequences),
@@ -40,7 +39,7 @@ func logCompletionRequest(log *zap.Logger, data []byte, prod, private bool, cid 
 	}
 }
 
-func logCompletionResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCompletionResponse(log *zap.Logger, data []byte, prod, private bool) {
 	cr := &anthropic.CompletionResponse{}
 	err := json.Unmarshal(data, cr)
 	if err != nil {
@@ -50,7 +49,6 @@ func logCompletionResponse(log *zap.Logger, data []byte, prod, private bool, cid
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("stop_reason", cr.StopReason),
 			zap.String("model", cr.Model),
 		}

--- a/internal/server/web/proxy/file.go
+++ b/internal/server/web/proxy/file.go
@@ -9,11 +9,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logListFilesRequest(log *zap.Logger, prod bool, cid string, params map[string]string) {
+func logListFilesRequest(log *zap.Logger, prod bool, params map[string]string) {
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		if v, ok := params["purpose"]; ok {
 			fields = append(fields, zap.String("purpose", v))
@@ -23,7 +21,7 @@ func logListFilesRequest(log *zap.Logger, prod bool, cid string, params map[stri
 	}
 }
 
-func logListFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logListFilesResponse(log *zap.Logger, data []byte, prod bool) {
 	files := &goopenai.FilesList{}
 	err := json.Unmarshal(data, files)
 	if err != nil {
@@ -33,7 +31,6 @@ func logListFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("files", files.Files),
 		}
 
@@ -41,10 +38,9 @@ func logListFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
 	}
 }
 
-func logRetrieveFileRequest(log *zap.Logger, prod bool, cid, fid string) {
+func logRetrieveFileRequest(log *zap.Logger, prod bool, fid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("file_id", fid),
 		}
 
@@ -52,7 +48,7 @@ func logRetrieveFileRequest(log *zap.Logger, prod bool, cid, fid string) {
 	}
 }
 
-func logRetrieveFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logRetrieveFileResponse(log *zap.Logger, data []byte, prod bool) {
 	file := &goopenai.File{}
 	err := json.Unmarshal(data, file)
 	if err != nil {
@@ -62,7 +58,6 @@ func logRetrieveFileResponse(log *zap.Logger, data []byte, prod bool, cid string
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", file.ID),
 			zap.Int("bytes", file.Bytes),
 			zap.Int64("createdAt", file.CreatedAt),
@@ -77,10 +72,9 @@ func logRetrieveFileResponse(log *zap.Logger, data []byte, prod bool, cid string
 	}
 }
 
-func logDeleteFileRequest(log *zap.Logger, prod bool, cid, fid string) {
+func logDeleteFileRequest(log *zap.Logger, prod bool, fid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("file_id", fid),
 		}
 
@@ -88,7 +82,7 @@ func logDeleteFileRequest(log *zap.Logger, prod bool, cid, fid string) {
 	}
 }
 
-func logDeleteFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logDeleteFileResponse(log *zap.Logger, data []byte, prod bool) {
 	dr := &DeletionResponse{}
 	err := json.Unmarshal(data, dr)
 	if err != nil {
@@ -98,7 +92,6 @@ func logDeleteFileResponse(log *zap.Logger, data []byte, prod bool, cid string) 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", dr.Id),
 			zap.String("object", dr.Object),
 			zap.Bool("deleted", dr.Deleted),
@@ -108,10 +101,9 @@ func logDeleteFileResponse(log *zap.Logger, data []byte, prod bool, cid string) 
 	}
 }
 
-func logRetrieveFileContentRequest(log *zap.Logger, prod bool, cid, fid string) {
+func logRetrieveFileContentRequest(log *zap.Logger, prod bool, fid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("file_id", fid),
 		}
 
@@ -119,20 +111,17 @@ func logRetrieveFileContentRequest(log *zap.Logger, prod bool, cid, fid string) 
 	}
 }
 
-func logRetrieveFileContentResponse(log *zap.Logger, prod bool, cid string) {
+func logRetrieveFileContentResponse(log *zap.Logger, prod bool) {
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		log.Info("openai retrieve file content response", fields...)
 	}
 }
 
-func logUploadFileRequest(log *zap.Logger, prod bool, cid, purpose string) {
+func logUploadFileRequest(log *zap.Logger, prod bool, purpose string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("purpose", purpose),
 		}
 
@@ -140,7 +129,7 @@ func logUploadFileRequest(log *zap.Logger, prod bool, cid, purpose string) {
 	}
 }
 
-func logUploadFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logUploadFileResponse(log *zap.Logger, data []byte, prod bool) {
 	file := &goopenai.File{}
 	err := json.Unmarshal(data, file)
 	if err != nil {
@@ -150,7 +139,6 @@ func logUploadFileResponse(log *zap.Logger, data []byte, prod bool, cid string) 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", file.ID),
 			zap.Int("bytes", file.Bytes),
 			zap.Int64("createdAt", file.CreatedAt),

--- a/internal/server/web/proxy/image.go
+++ b/internal/server/web/proxy/image.go
@@ -8,10 +8,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateImageRequest(log *zap.Logger, ir *goopenai.ImageRequest, prod, private bool, cid string) {
+func logCreateImageRequest(log *zap.Logger, ir *goopenai.ImageRequest, prod, private bool) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", ir.Model),
 			zap.Int("n", ir.N),
 			zap.String("quality", ir.Quality),
@@ -29,11 +28,9 @@ func logCreateImageRequest(log *zap.Logger, ir *goopenai.ImageRequest, prod, pri
 	}
 }
 
-func logEditImageRequest(log *zap.Logger, prompt, model string, n int, size, responseFormat, user string, prod, private bool, cid string) {
+func logEditImageRequest(log *zap.Logger, prompt, model string, n int, size, responseFormat, user string, prod, private bool) {
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		if !private && len(prompt) != 0 {
 			fields = append(fields, zap.String("prompt", prompt))
@@ -63,11 +60,9 @@ func logEditImageRequest(log *zap.Logger, prompt, model string, n int, size, res
 	}
 }
 
-func logImageVariationsRequest(log *zap.Logger, model string, n int, size, responseFormat, user string, prod bool, cid string) {
+func logImageVariationsRequest(log *zap.Logger, model string, n int, size, responseFormat, user string, prod bool) {
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		if len(model) != 0 {
 			fields = append(fields, zap.String("model", model))
@@ -93,7 +88,7 @@ func logImageVariationsRequest(log *zap.Logger, model string, n int, size, respo
 	}
 }
 
-func logImageResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logImageResponse(log *zap.Logger, data []byte, prod, private bool) {
 	ir := &goopenai.ImageResponse{}
 	err := json.Unmarshal(data, ir)
 	if err != nil {
@@ -103,7 +98,6 @@ func logImageResponse(log *zap.Logger, data []byte, prod, private bool, cid stri
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Int64("created", ir.Created),
 		}
 

--- a/internal/server/web/proxy/message.go
+++ b/internal/server/web/proxy/message.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateMessageRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateMessageRequest(log *zap.Logger, data []byte, prod, private bool) {
 	mr := &openai.MessageRequest{}
 	err := json.Unmarshal(data, mr)
 	if err != nil {
@@ -19,7 +19,6 @@ func logCreateMessageRequest(log *zap.Logger, data []byte, prod, private bool, c
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("role", mr.Role),
 			zap.Any("file_ids", mr.FileIds),
 			zap.Any("metadata", mr.Metadata),
@@ -33,7 +32,7 @@ func logCreateMessageRequest(log *zap.Logger, data []byte, prod, private bool, c
 	}
 }
 
-func logMessageResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logMessageResponse(log *zap.Logger, data []byte, prod, private bool) {
 	m := &goopenai.Message{}
 	err := json.Unmarshal(data, m)
 	if err != nil {
@@ -49,7 +48,6 @@ func logMessageResponse(log *zap.Logger, data []byte, prod, private bool, cid st
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", m.ID),
 			zap.String("object", m.Object),
 			zap.Int("created_at", m.CreatedAt),
@@ -65,10 +63,9 @@ func logMessageResponse(log *zap.Logger, data []byte, prod, private bool, cid st
 	}
 }
 
-func logRetrieveMessageRequest(log *zap.Logger, prod bool, cid, mid, tid string) {
+func logRetrieveMessageRequest(log *zap.Logger, prod bool, mid, tid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("message_id", mid),
 		}
@@ -77,7 +74,7 @@ func logRetrieveMessageRequest(log *zap.Logger, prod bool, cid, mid, tid string)
 	}
 }
 
-func logModifyMessageRequest(log *zap.Logger, data []byte, prod, private bool, cid, tid, mid string) {
+func logModifyMessageRequest(log *zap.Logger, data []byte, prod, private bool, tid, mid string) {
 	mr := &goopenai.MessageRequest{}
 	err := json.Unmarshal(data, mr)
 	if err != nil {
@@ -87,7 +84,6 @@ func logModifyMessageRequest(log *zap.Logger, data []byte, prod, private bool, c
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("message_id", mid),
 			zap.Any("metadata", mr.Metadata),
@@ -101,10 +97,9 @@ func logModifyMessageRequest(log *zap.Logger, data []byte, prod, private bool, c
 	}
 }
 
-func logListMessagesRequest(log *zap.Logger, prod bool, cid, tid string) {
+func logListMessagesRequest(log *zap.Logger, prod bool, tid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 		}
 
@@ -112,7 +107,7 @@ func logListMessagesRequest(log *zap.Logger, prod bool, cid, tid string) {
 	}
 }
 
-func logListMessagesResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logListMessagesResponse(log *zap.Logger, data []byte, prod, private bool) {
 	ms := &goopenai.MessagesList{}
 	err := json.Unmarshal(data, ms)
 	if err != nil {
@@ -130,7 +125,6 @@ func logListMessagesResponse(log *zap.Logger, data []byte, prod, private bool, c
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("messages", ms.Messages),
 		}
 

--- a/internal/server/web/proxy/message_file.go
+++ b/internal/server/web/proxy/message_file.go
@@ -8,10 +8,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logRetrieveMessageFileRequest(log *zap.Logger, prod bool, cid, tid, mid, fid string) {
+func logRetrieveMessageFileRequest(log *zap.Logger, prod bool, tid, mid, fid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("message_id", mid),
 			zap.String("file_id", fid),
@@ -21,7 +20,7 @@ func logRetrieveMessageFileRequest(log *zap.Logger, prod bool, cid, tid, mid, fi
 	}
 }
 
-func logRetrieveMessageFileResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logRetrieveMessageFileResponse(log *zap.Logger, data []byte, prod bool) {
 	mf := &goopenai.MessageFile{}
 	err := json.Unmarshal(data, mf)
 	if err != nil {
@@ -31,7 +30,6 @@ func logRetrieveMessageFileResponse(log *zap.Logger, data []byte, prod bool, cid
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", mf.ID),
 			zap.String("object", mf.Object),
 			zap.Int("created_at", mf.CreatedAt),
@@ -42,10 +40,9 @@ func logRetrieveMessageFileResponse(log *zap.Logger, data []byte, prod bool, cid
 	}
 }
 
-func logListMessageFilesRequest(log *zap.Logger, prod bool, cid, tid, mid string, params map[string]string) {
+func logListMessageFilesRequest(log *zap.Logger, prod bool, tid, mid string, params map[string]string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("message_id", mid),
 		}
@@ -70,7 +67,7 @@ func logListMessageFilesRequest(log *zap.Logger, prod bool, cid, tid, mid string
 	}
 }
 
-func logListMessageFilesResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logListMessageFilesResponse(log *zap.Logger, data []byte, prod bool) {
 	files := &goopenai.MessageFilesList{}
 	err := json.Unmarshal(data, files)
 	if err != nil {
@@ -80,7 +77,6 @@ func logListMessageFilesResponse(log *zap.Logger, data []byte, prod bool, cid st
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("message_files", files.MessageFiles),
 		}
 

--- a/internal/server/web/proxy/models.go
+++ b/internal/server/web/proxy/models.go
@@ -8,7 +8,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logListModelsResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logListModelsResponse(log *zap.Logger, data []byte, prod bool) {
 	models := &goopenai.ModelsList{}
 	err := json.Unmarshal(data, models)
 	if err != nil {
@@ -18,7 +18,6 @@ func logListModelsResponse(log *zap.Logger, data []byte, prod bool, cid string) 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("models", models.Models),
 		}
 
@@ -26,10 +25,9 @@ func logListModelsResponse(log *zap.Logger, data []byte, prod bool, cid string) 
 	}
 }
 
-func logRetrieveModelRequest(log *zap.Logger, prod bool, cid, model string) {
+func logRetrieveModelRequest(log *zap.Logger, prod bool, model string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", model),
 		}
 
@@ -37,7 +35,7 @@ func logRetrieveModelRequest(log *zap.Logger, prod bool, cid, model string) {
 	}
 }
 
-func logRetrieveModelResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logRetrieveModelResponse(log *zap.Logger, data []byte, prod bool) {
 	model := &goopenai.Model{}
 	err := json.Unmarshal(data, model)
 	if err != nil {
@@ -47,7 +45,6 @@ func logRetrieveModelResponse(log *zap.Logger, data []byte, prod bool, cid strin
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", model.ID),
 			zap.Int64("created", model.CreatedAt),
 			zap.String("object", model.Object),
@@ -58,10 +55,9 @@ func logRetrieveModelResponse(log *zap.Logger, data []byte, prod bool, cid strin
 	}
 }
 
-func logDeleteModelRequest(log *zap.Logger, prod bool, cid, model string) {
+func logDeleteModelRequest(log *zap.Logger, prod bool, model string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", model),
 		}
 
@@ -75,7 +71,7 @@ type DeletionResponse struct {
 	Deleted bool   `json:"deleted"`
 }
 
-func logDeleteModelResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logDeleteModelResponse(log *zap.Logger, data []byte, prod bool) {
 	resp := &DeletionResponse{}
 	err := json.Unmarshal(data, resp)
 	if err != nil {
@@ -85,7 +81,6 @@ func logDeleteModelResponse(log *zap.Logger, data []byte, prod bool, cid string)
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", resp.Id),
 			zap.String("object", resp.Object),
 			zap.Bool("deleted", resp.Deleted),

--- a/internal/server/web/proxy/moderation.go
+++ b/internal/server/web/proxy/moderation.go
@@ -13,7 +13,7 @@ type ModerationRequest struct {
 	Model string `json:"model"`
 }
 
-func logCreateModerationRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateModerationRequest(log *zap.Logger, data []byte, prod, private bool) {
 	mr := &ModerationRequest{}
 	err := json.Unmarshal(data, mr)
 	if err != nil {
@@ -22,9 +22,7 @@ func logCreateModerationRequest(log *zap.Logger, data []byte, prod, private bool
 	}
 
 	if prod {
-		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
-		}
+		fields := []zapcore.Field{}
 
 		if !private {
 			strInput, ok := mr.Input.(string)
@@ -42,7 +40,7 @@ func logCreateModerationRequest(log *zap.Logger, data []byte, prod, private bool
 	}
 }
 
-func logCreateModerationResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logCreateModerationResponse(log *zap.Logger, data []byte, prod bool) {
 	mr := &goopenai.ModerationResponse{}
 	err := json.Unmarshal(data, mr)
 	if err != nil {
@@ -52,7 +50,6 @@ func logCreateModerationResponse(log *zap.Logger, data []byte, prod bool, cid st
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", mr.ID),
 			zap.String("model", mr.Model),
 			zap.Any("results", mr.Results),

--- a/internal/server/web/proxy/proxy.go
+++ b/internal/server/web/proxy/proxy.go
@@ -94,14 +94,14 @@ func NewProxyServer(log *zap.Logger, mode, privacyMode string, c cache, m KeyMan
 
 	// audios
 	router.POST("/api/providers/openai/v1/audio/speech", getSpeechHandler(prod, client, timeOut))
-	router.POST("/api/providers/openai/v1/audio/transcriptions", getTranscriptionsHandler(prod, client, log, timeOut, e))
-	router.POST("/api/providers/openai/v1/audio/translations", getTranslationsHandler(prod, client, log, timeOut, e))
+	router.POST("/api/providers/openai/v1/audio/transcriptions", getTranscriptionsHandler(prod, client, timeOut, e))
+	router.POST("/api/providers/openai/v1/audio/translations", getTranslationsHandler(prod, client, timeOut, e))
 
 	// completions
-	router.POST("/api/providers/openai/v1/chat/completions", getChatCompletionHandler(prod, private, client, log, e, timeOut))
+	router.POST("/api/providers/openai/v1/chat/completions", getChatCompletionHandler(prod, private, client, e, timeOut))
 
 	// embeddings
-	router.POST("/api/providers/openai/v1/embeddings", getEmbeddingHandler(prod, private, client, log, e, timeOut))
+	router.POST("/api/providers/openai/v1/embeddings", getEmbeddingHandler(prod, private, client, e, timeOut))
 
 	// moderations
 	router.POST("/api/providers/openai/v1/moderations", getPassThroughHandler(prod, private, client, timeOut))
@@ -164,12 +164,12 @@ func NewProxyServer(log *zap.Logger, mode, privacyMode string, c cache, m KeyMan
 	router.POST("/api/providers/openai/v1/images/variations", getPassThroughHandler(prod, private, client, timeOut))
 
 	// azure
-	router.POST("/api/providers/azure/openai/deployments/:deployment_id/chat/completions", getAzureChatCompletionHandler(prod, private, client, log, aoe, timeOut))
-	router.POST("/api/providers/azure/openai/deployments/:deployment_id/embeddings", getAzureEmbeddingsHandler(prod, private, client, log, aoe, timeOut))
+	router.POST("/api/providers/azure/openai/deployments/:deployment_id/chat/completions", getAzureChatCompletionHandler(prod, private, client, aoe, timeOut))
+	router.POST("/api/providers/azure/openai/deployments/:deployment_id/embeddings", getAzureEmbeddingsHandler(prod, private, client, aoe, timeOut))
 
 	// anthropic
 	router.POST("/api/providers/anthropic/v1/complete", getCompletionHandler(prod, private, client, timeOut))
-	router.POST("/api/providers/anthropic/v1/messages", getMessagesHandler(prod, private, client, log, ae, timeOut))
+	router.POST("/api/providers/anthropic/v1/messages", getMessagesHandler(prod, private, client, ae, timeOut))
 
 	// vllm
 	router.POST("/api/providers/vllm/v1/chat/completions", getVllmChatCompletionsHandler(prod, private, client, timeOut))
@@ -178,13 +178,13 @@ func NewProxyServer(log *zap.Logger, mode, privacyMode string, c cache, m KeyMan
 	// deepinfra
 	router.POST("/api/providers/deepinfra/v1/chat/completions", getDeepinfraChatCompletionsHandler(prod, private, client, timeOut))
 	router.POST("/api/providers/deepinfra/v1/completions", getDeepinfraCompletionsHandler(prod, private, client, timeOut))
-	router.POST("/api/providers/deepinfra/v1/embeddings", getDeepinfraEmbeddingsHandler(prod, private, client, log, die, timeOut))
+	router.POST("/api/providers/deepinfra/v1/embeddings", getDeepinfraEmbeddingsHandler(prod, private, client, die, timeOut))
 
 	// custom provider
 	router.POST("/api/custom/providers/:provider/*wildcard", getCustomProviderHandler(prod, client, timeOut))
 
 	// custom route
-	router.POST("/api/routes/*route", getRouteHandler(prod, c, aoe, e, client, log, r))
+	router.POST("/api/routes/*route", getRouteHandler(prod, c, aoe, e, client, r))
 
 	srv := &http.Server{
 		Addr:    ":8002",
@@ -259,8 +259,6 @@ func getPassThroughHandler(prod, private bool, client http.Client, timeOut time.
 			JSON(c, http.StatusInternalServerError, "[BricksLLM] context is empty")
 			return
 		}
-
-		cid := c.GetString(logFiledNameCorrelationId)
 
 		ctx, cancel := context.WithTimeout(context.Background(), timeOut)
 		defer cancel()
@@ -494,163 +492,163 @@ func getPassThroughHandler(prod, private bool, client http.Client, timeOut time.
 			stats.Timing("bricksllm.proxy.get_pass_through_handler.success_latency", dur, tags, 1)
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants" && c.Request.Method == http.MethodPost {
-				logAssistantResponse(log, bytes, prod, private, cid)
+				logAssistantResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id" && c.Request.Method == http.MethodGet {
-				logAssistantResponse(log, bytes, prod, private, cid)
+				logAssistantResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id" && c.Request.Method == http.MethodPost {
-				logAssistantResponse(log, bytes, prod, private, cid)
+				logAssistantResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id" && c.Request.Method == http.MethodDelete {
-				logDeleteAssistantResponse(log, bytes, prod, cid)
+				logDeleteAssistantResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants" && c.Request.Method == http.MethodGet {
-				logListAssistantsResponse(log, bytes, prod, private, cid)
+				logListAssistantsResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id/files" && c.Request.Method == http.MethodPost {
-				logAssistantFileResponse(log, bytes, prod, cid)
+				logAssistantFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id/files/:file_id" && c.Request.Method == http.MethodGet {
-				logAssistantFileResponse(log, bytes, prod, cid)
+				logAssistantFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id/files/:file_id" && c.Request.Method == http.MethodDelete {
-				logDeleteAssistantFileResponse(log, bytes, prod, cid)
+				logDeleteAssistantFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/assistants/:assistant_id/files" && c.Request.Method == http.MethodGet {
-				logListAssistantFilesResponse(log, bytes, prod, cid)
+				logListAssistantFilesResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads" && c.Request.Method == http.MethodPost {
-				logThreadResponse(log, bytes, prod, cid)
+				logThreadResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id" && c.Request.Method == http.MethodGet {
-				logThreadResponse(log, bytes, prod, cid)
+				logThreadResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id" && c.Request.Method == http.MethodPost {
-				logThreadResponse(log, bytes, prod, cid)
+				logThreadResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id" && c.Request.Method == http.MethodDelete {
-				logDeleteThreadResponse(log, bytes, prod, cid)
+				logDeleteThreadResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages" && c.Request.Method == http.MethodPost {
-				logMessageResponse(log, bytes, prod, private, cid)
+				logMessageResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages/:message_id" && c.Request.Method == http.MethodGet {
-				logMessageResponse(log, bytes, prod, private, cid)
+				logMessageResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages/:message_id" && c.Request.Method == http.MethodPost {
-				logMessageResponse(log, bytes, prod, private, cid)
+				logMessageResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages" && c.Request.Method == http.MethodGet {
-				logListMessagesResponse(log, bytes, prod, private, cid)
+				logListMessagesResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages/:message_id/files/:file_id" && c.Request.Method == http.MethodGet {
-				logRetrieveMessageFileResponse(log, bytes, prod, cid)
+				logRetrieveMessageFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/messages/:message_id/files" && c.Request.Method == http.MethodGet {
-				logListMessageFilesResponse(log, bytes, prod, cid)
+				logListMessageFilesResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs" && c.Request.Method == http.MethodPost {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id" && c.Request.Method == http.MethodGet {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id" && c.Request.Method == http.MethodPost {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs" && c.Request.Method == http.MethodGet {
-				logListRunsResponse(log, bytes, prod, private, cid)
+				logListRunsResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id/submit_tool_outputs" && c.Request.Method == http.MethodPost {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id/cancel" && c.Request.Method == http.MethodPost {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/runs" && c.Request.Method == http.MethodPost {
-				logRunResponse(log, bytes, prod, private, cid)
+				logRunResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id/steps/:step_id" && c.Request.Method == http.MethodGet {
-				logRetrieveRunStepResponse(log, bytes, prod, cid)
+				logRetrieveRunStepResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/threads/:thread_id/runs/:run_id/steps" && c.Request.Method == http.MethodGet {
-				logListRunStepsResponse(log, bytes, prod, cid)
+				logListRunStepsResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/moderations" && c.Request.Method == http.MethodPost {
-				logCreateModerationResponse(log, bytes, prod, cid)
+				logCreateModerationResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/models" && c.Request.Method == http.MethodGet {
-				logListModelsResponse(log, bytes, prod, cid)
+				logListModelsResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/models/:model" && c.Request.Method == http.MethodGet {
-				logRetrieveModelResponse(log, bytes, prod, cid)
+				logRetrieveModelResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/models/:model" && c.Request.Method == http.MethodDelete {
-				logDeleteModelResponse(log, bytes, prod, cid)
+				logDeleteModelResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/files" && c.Request.Method == http.MethodGet {
-				logListFilesResponse(log, bytes, prod, cid)
+				logListFilesResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/files" && c.Request.Method == http.MethodPost {
-				logUploadFileResponse(log, bytes, prod, cid)
+				logUploadFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/files/:file_id" && c.Request.Method == http.MethodDelete {
-				logDeleteFileResponse(log, bytes, prod, cid)
+				logDeleteFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/files/:file_id" && c.Request.Method == http.MethodGet {
-				logRetrieveFileResponse(log, bytes, prod, cid)
+				logRetrieveFileResponse(log, bytes, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/files/:file_id/content" && c.Request.Method == http.MethodGet {
-				logRetrieveFileContentResponse(log, prod, cid)
+				logRetrieveFileContentResponse(log, prod)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/images/generations" && c.Request.Method == http.MethodPost {
-				logImageResponse(log, bytes, prod, private, cid)
+				logImageResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/images/edits" && c.Request.Method == http.MethodPost {
-				logImageResponse(log, bytes, prod, private, cid)
+				logImageResponse(log, bytes, prod, private)
 			}
 
 			if c.FullPath() == "/api/providers/openai/v1/images/variations" && c.Request.Method == http.MethodPost {
-				logImageResponse(log, bytes, prod, private, cid)
+				logImageResponse(log, bytes, prod, private)
 			}
 		}
 
@@ -664,7 +662,7 @@ func getPassThroughHandler(prod, private bool, client http.Client, timeOut time.
 				logError(log, "error when unmarshalling openai pass through error response body", prod, err)
 			}
 
-			logOpenAiError(log, prod, cid, errorRes)
+			logOpenAiError(log, prod, errorRes)
 		}
 
 		for name, values := range res.Header {
@@ -874,8 +872,9 @@ type EmbeddingResponseBase64 struct {
 	Usage  goopenai.Usage             `json:"usage"`
 }
 
-func getEmbeddingHandler(prod, private bool, client http.Client, log *zap.Logger, e estimator, timeOut time.Duration) gin.HandlerFunc {
+func getEmbeddingHandler(prod, private bool, client http.Client, e estimator, timeOut time.Duration) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		stats.Incr("bricksllm.proxy.get_embedding_handler.requests", nil, 1)
 		if c == nil || c.Request == nil {
 			JSON(c, http.StatusInternalServerError, "[BricksLLM] context is empty")
@@ -889,8 +888,6 @@ func getEmbeddingHandler(prod, private bool, client http.Client, log *zap.Logger
 		// 	JSON(c, http.StatusUnauthorized, "[BricksLLM] api key is not registered")
 		// 	return
 		// }
-
-		id := c.GetString(logFiledNameCorrelationId)
 
 		ctx, cancel := context.WithTimeout(context.Background(), timeOut)
 		defer cancel()
@@ -955,13 +952,13 @@ func getEmbeddingHandler(prod, private bool, client http.Client, log *zap.Logger
 			totalTokens := 0
 			if err == nil {
 				if format == "base64" {
-					logBase64EmbeddingResponse(log, prod, private, id, base64ChatRes)
+					logBase64EmbeddingResponse(log, prod, private, base64ChatRes)
 					promptTokenCounts = base64ChatRes.Usage.PromptTokens
 					totalTokens = base64ChatRes.Usage.TotalTokens
 				}
 
 				if format != "base64" {
-					logEmbeddingResponse(log, prod, private, id, chatRes)
+					logEmbeddingResponse(log, prod, private, chatRes)
 					promptTokenCounts = chatRes.Usage.PromptTokens
 					totalTokens = chatRes.Usage.TotalTokens
 				}
@@ -994,7 +991,7 @@ func getEmbeddingHandler(prod, private bool, client http.Client, log *zap.Logger
 				logError(log, "error when unmarshalling openai embedding error response body", prod, err)
 			}
 
-			logOpenAiError(log, prod, id, errorRes)
+			logOpenAiError(log, prod, errorRes)
 		}
 
 		for name, values := range res.Header {
@@ -1117,11 +1114,10 @@ func (ps *ProxyServer) Run() {
 	}()
 }
 
-func logEmbeddingResponse(log *zap.Logger, prod, private bool, cid string, r *EmbeddingResponse) {
+func logEmbeddingResponse(log *zap.Logger, prod, private bool, r *EmbeddingResponse) {
 	if prod {
 		log.Info("openai embeddings response",
 			zap.Time("createdAt", time.Now()),
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Object("response", zapcore.ObjectMarshalerFunc(
 				func(enc zapcore.ObjectEncoder) error {
 					enc.AddString("object", r.Object)
@@ -1166,11 +1162,10 @@ func logEmbeddingResponse(log *zap.Logger, prod, private bool, cid string, r *Em
 	}
 }
 
-func logBase64EmbeddingResponse(log *zap.Logger, prod, private bool, cid string, r *EmbeddingResponseBase64) {
+func logBase64EmbeddingResponse(log *zap.Logger, prod, private bool, r *EmbeddingResponseBase64) {
 	if prod {
 		log.Info("openai embeddings response",
 			zap.Time("createdAt", time.Now()),
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Object("response", zapcore.ObjectMarshalerFunc(
 				func(enc zapcore.ObjectEncoder) error {
 					enc.AddString("object", r.Object)
@@ -1209,11 +1204,10 @@ func logBase64EmbeddingResponse(log *zap.Logger, prod, private bool, cid string,
 	}
 }
 
-func logChatCompletionResponse(log *zap.Logger, prod, private bool, cid string, r *goopenai.ChatCompletionResponse) {
+func logChatCompletionResponse(log *zap.Logger, prod, private bool, r *goopenai.ChatCompletionResponse) {
 	if prod {
 		log.Info("openai chat completion response",
 			zap.Time("createdAt", time.Now()),
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Object("response", zapcore.ObjectMarshalerFunc(
 				func(enc zapcore.ObjectEncoder) error {
 					enc.AddString("id", r.ID)
@@ -1260,10 +1254,9 @@ func logChatCompletionResponse(log *zap.Logger, prod, private bool, cid string, 
 	}
 }
 
-func logEmbeddingRequest(log *zap.Logger, prod, private bool, id string, r *goopenai.EmbeddingRequest) {
+func logEmbeddingRequest(log *zap.Logger, prod, private bool, r *goopenai.EmbeddingRequest) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, id),
 			zap.String("model", string(r.Model)),
 			zap.String("encoding_format", string(r.EncodingFormat)),
 			zap.String("user", r.User),
@@ -1277,11 +1270,10 @@ func logEmbeddingRequest(log *zap.Logger, prod, private bool, id string, r *goop
 	}
 }
 
-func logRequest(log *zap.Logger, prod, private bool, id string, r *goopenai.ChatCompletionRequest) {
+func logRequest(log *zap.Logger, prod, private bool, r *goopenai.ChatCompletionRequest) {
 	if prod {
 		log.Info("openai chat completion request",
 			zap.Time("createdAt", time.Now()),
-			zap.String(logFiledNameCorrelationId, id),
 			zap.Object("request", zapcore.ObjectMarshalerFunc(
 				func(enc zapcore.ObjectEncoder) error {
 					enc.AddString("model", r.Model)
@@ -1416,13 +1408,13 @@ func logRequest(log *zap.Logger, prod, private bool, id string, r *goopenai.Chat
 	}
 }
 
-func logOpenAiError(log *zap.Logger, prod bool, id string, errRes *goopenai.ErrorResponse) {
+func logOpenAiError(log *zap.Logger, prod bool, errRes *goopenai.ErrorResponse) {
 	if prod {
-		log.Info("openai error response", zap.String(logFiledNameCorrelationId, id), zap.Any("error", errRes))
+		log.Info("openai error response", zap.Any("error", errRes))
 		return
 	}
 
-	log.Sugar().Infof("correlationId:%s | %s ", id, "openai error response")
+	log.Info("openai error response")
 }
 
 func logError(log *zap.Logger, msg string, prod bool, err error) {
@@ -1430,7 +1422,7 @@ func logError(log *zap.Logger, msg string, prod bool, err error) {
 		log.Debug(msg, zap.Error(err))
 		return
 	}
-	log.Debug(fmt.Sprintf("correlationId:%s | %s | %v", msg, err))
+	log.Debug(fmt.Sprintf("%s | %v", msg, err))
 }
 
 func (ps *ProxyServer) Shutdown(ctx context.Context) error {

--- a/internal/server/web/proxy/route.go
+++ b/internal/server/web/proxy/route.go
@@ -13,9 +13,9 @@ import (
 	"github.com/bricks-cloud/bricksllm/internal/provider"
 	"github.com/bricks-cloud/bricksllm/internal/route"
 	"github.com/bricks-cloud/bricksllm/internal/stats"
+	"github.com/bricks-cloud/bricksllm/internal/util"
 	"github.com/gin-gonic/gin"
 	goopenai "github.com/sashabaranov/go-openai"
-	"go.uber.org/zap"
 )
 
 type routeManager interface {
@@ -27,8 +27,9 @@ type cache interface {
 	GetBytes(key string) ([]byte, error)
 }
 
-func getRouteHandler(prod bool, ca cache, aoe azureEstimator, e estimator, client http.Client, log *zap.Logger, rec recorder) gin.HandlerFunc {
+func getRouteHandler(prod bool, ca cache, aoe azureEstimator, e estimator, client http.Client, rec recorder) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		log := util.GetLogFromCtx(c)
 		trueStart := time.Now()
 
 		tags := []string{
@@ -85,9 +86,9 @@ func getRouteHandler(prod bool, ca cache, aoe azureEstimator, e estimator, clien
 			settingsMap[setting.Id] = setting
 		}
 
-		cid := c.GetString(logFiledNameCorrelationId)
 		start := time.Now()
 
+		cid := c.GetString(util.STRING_CORRELATION_ID)
 		rreq := &route.Request{
 			Settings:      settingsMap,
 			Key:           kc,
@@ -176,7 +177,7 @@ func getRouteHandler(prod bool, ca cache, aoe azureEstimator, e estimator, clien
 				logError(log, "error when unmarshalling azure openai embedding error response body", prod, err)
 			}
 
-			logOpenAiError(log, prod, cid, errorRes)
+			logOpenAiError(log, prod, errorRes)
 		}
 
 		for name, values := range res.Header {

--- a/internal/server/web/proxy/run.go
+++ b/internal/server/web/proxy/run.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateRunRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateRunRequest(log *zap.Logger, data []byte, prod, private bool) {
 	rr := &goopenai.RunRequest{}
 	err := json.Unmarshal(data, rr)
 	if err != nil {
@@ -19,7 +19,6 @@ func logCreateRunRequest(log *zap.Logger, data []byte, prod, private bool, cid s
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", rr.AssistantID),
 			zap.String("model", rr.Model),
 			zap.Any("tools", rr.Tools),
@@ -34,7 +33,7 @@ func logCreateRunRequest(log *zap.Logger, data []byte, prod, private bool, cid s
 	}
 }
 
-func logRunResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logRunResponse(log *zap.Logger, data []byte, prod, private bool) {
 	r := &goopenai.Run{}
 	err := json.Unmarshal(data, r)
 	if err != nil {
@@ -44,7 +43,6 @@ func logRunResponse(log *zap.Logger, data []byte, prod, private bool, cid string
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", r.ID),
 			zap.String("object", r.Object),
 			zap.Int64("created_at", r.CreatedAt),
@@ -72,10 +70,9 @@ func logRunResponse(log *zap.Logger, data []byte, prod, private bool, cid string
 	}
 }
 
-func logRetrieveRunRequest(log *zap.Logger, prod bool, cid, tid, rid string) {
+func logRetrieveRunRequest(log *zap.Logger, prod bool, tid, rid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 		}
@@ -84,7 +81,7 @@ func logRetrieveRunRequest(log *zap.Logger, prod bool, cid, tid, rid string) {
 	}
 }
 
-func logModifyRunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+func logModifyRunRequest(log *zap.Logger, data []byte, prod bool, tid, rid string) {
 	rr := &goopenai.RunRequest{}
 	err := json.Unmarshal(data, rr)
 	if err != nil {
@@ -94,7 +91,6 @@ func logModifyRunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid 
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 			zap.Any("metadata", rr.Metadata),
@@ -104,10 +100,9 @@ func logModifyRunRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid 
 	}
 }
 
-func logListRunsRequest(log *zap.Logger, prod bool, cid, tid string, params map[string]string) {
+func logListRunsRequest(log *zap.Logger, prod bool, tid string, params map[string]string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 		}
 
@@ -131,7 +126,7 @@ func logListRunsRequest(log *zap.Logger, prod bool, cid, tid string, params map[
 	}
 }
 
-func logListRunsResponse(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logListRunsResponse(log *zap.Logger, data []byte, prod, private bool) {
 	r := &goopenai.RunList{}
 	err := json.Unmarshal(data, r)
 	if err != nil {
@@ -147,7 +142,6 @@ func logListRunsResponse(log *zap.Logger, data []byte, prod, private bool, cid s
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("runs", r.Runs),
 		}
 
@@ -155,7 +149,7 @@ func logListRunsResponse(log *zap.Logger, data []byte, prod, private bool, cid s
 	}
 }
 
-func logSubmitToolOutputsRequest(log *zap.Logger, data []byte, prod bool, cid, tid, rid string) {
+func logSubmitToolOutputsRequest(log *zap.Logger, data []byte, prod bool, tid, rid string) {
 	r := &goopenai.SubmitToolOutputsRequest{}
 	err := json.Unmarshal(data, r)
 	if err != nil {
@@ -165,7 +159,6 @@ func logSubmitToolOutputsRequest(log *zap.Logger, data []byte, prod bool, cid, t
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 			zap.Any("tool_outputs", r.ToolOutputs),
@@ -175,10 +168,9 @@ func logSubmitToolOutputsRequest(log *zap.Logger, data []byte, prod bool, cid, t
 	}
 }
 
-func logCancelARunRequest(log *zap.Logger, prod bool, cid, tid, rid string) {
+func logCancelARunRequest(log *zap.Logger, prod bool, tid, rid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 		}
@@ -187,7 +179,7 @@ func logCancelARunRequest(log *zap.Logger, prod bool, cid, tid, rid string) {
 	}
 }
 
-func logCreateThreadAndRunRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateThreadAndRunRequest(log *zap.Logger, data []byte, prod, private bool) {
 	r := &openai.CreateThreadAndRunRequest{}
 	err := json.Unmarshal(data, r)
 	if err != nil {
@@ -198,7 +190,6 @@ func logCreateThreadAndRunRequest(log *zap.Logger, data []byte, prod, private bo
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("assistant_id", r.AssistantID),
 			zap.String("model", r.Model),
 			zap.Any("tools", r.Tools),
@@ -213,10 +204,9 @@ func logCreateThreadAndRunRequest(log *zap.Logger, data []byte, prod, private bo
 	}
 }
 
-func logRetrieveRunStepRequest(log *zap.Logger, prod bool, cid, tid, rid, sid string) {
+func logRetrieveRunStepRequest(log *zap.Logger, prod bool, tid, rid, sid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 			zap.String("step_id", sid),
@@ -226,7 +216,7 @@ func logRetrieveRunStepRequest(log *zap.Logger, prod bool, cid, tid, rid, sid st
 	}
 }
 
-func logRetrieveRunStepResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logRetrieveRunStepResponse(log *zap.Logger, data []byte, prod bool) {
 	rs := &goopenai.RunStep{}
 	err := json.Unmarshal(data, rs)
 	if err != nil {
@@ -236,7 +226,6 @@ func logRetrieveRunStepResponse(log *zap.Logger, data []byte, prod bool, cid str
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", rs.ID),
 			zap.String("object", rs.Object),
 			zap.Int64("created_at", rs.CreatedAt),
@@ -258,10 +247,9 @@ func logRetrieveRunStepResponse(log *zap.Logger, data []byte, prod bool, cid str
 	}
 }
 
-func logListRunStepsRequest(log *zap.Logger, prod bool, cid, tid, rid string, params map[string]string) {
+func logListRunStepsRequest(log *zap.Logger, prod bool, tid, rid string, params map[string]string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("thread_id", tid),
 			zap.String("run_id", rid),
 		}
@@ -286,7 +274,7 @@ func logListRunStepsRequest(log *zap.Logger, prod bool, cid, tid, rid string, pa
 	}
 }
 
-func logListRunStepsResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logListRunStepsResponse(log *zap.Logger, data []byte, prod bool) {
 	rsl := &goopenai.RunStepList{}
 	err := json.Unmarshal(data, rsl)
 	if err != nil {
@@ -296,7 +284,6 @@ func logListRunStepsResponse(log *zap.Logger, data []byte, prod bool, cid string
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("run_steps", rsl.RunSteps),
 		}
 

--- a/internal/server/web/proxy/thread.go
+++ b/internal/server/web/proxy/thread.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func logCreateThreadRequest(log *zap.Logger, data []byte, prod, private bool, cid string) {
+func logCreateThreadRequest(log *zap.Logger, data []byte, prod, private bool) {
 	tr := &openai.ThreadRequest{}
 	err := json.Unmarshal(data, tr)
 	if err != nil {
@@ -26,7 +26,6 @@ func logCreateThreadRequest(log *zap.Logger, data []byte, prod, private bool, ci
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.Any("metadata", tr.Metadata),
 			zap.Any("messages", tr.Messages),
 		}
@@ -35,7 +34,7 @@ func logCreateThreadRequest(log *zap.Logger, data []byte, prod, private bool, ci
 	}
 }
 
-func logThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logThreadResponse(log *zap.Logger, data []byte, prod bool) {
 	t := &goopenai.Thread{}
 	err := json.Unmarshal(data, t)
 	if err != nil {
@@ -45,7 +44,6 @@ func logThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", t.ID),
 			zap.String("object", t.Object),
 			zap.Int64("created_at", t.CreatedAt),
@@ -56,10 +54,9 @@ func logThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
 	}
 }
 
-func logRetrieveThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
+func logRetrieveThreadRequest(log *zap.Logger, prod bool, tid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", tid),
 		}
 
@@ -67,7 +64,7 @@ func logRetrieveThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
 	}
 }
 
-func logModifyThreadRequest(log *zap.Logger, data []byte, prod bool, cid, tid string) {
+func logModifyThreadRequest(log *zap.Logger, data []byte, prod bool, tid string) {
 	tr := &goopenai.ThreadRequest{}
 	err := json.Unmarshal(data, tr)
 	if err != nil {
@@ -77,7 +74,6 @@ func logModifyThreadRequest(log *zap.Logger, data []byte, prod bool, cid, tid st
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", tid),
 			zap.Any("metadata", tr.Metadata),
 		}
@@ -86,10 +82,9 @@ func logModifyThreadRequest(log *zap.Logger, data []byte, prod bool, cid, tid st
 	}
 }
 
-func logDeleteThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
+func logDeleteThreadRequest(log *zap.Logger, prod bool, tid string) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", tid),
 		}
 
@@ -97,7 +92,7 @@ func logDeleteThreadRequest(log *zap.Logger, prod bool, cid, tid string) {
 	}
 }
 
-func logDeleteThreadResponse(log *zap.Logger, data []byte, prod bool, cid string) {
+func logDeleteThreadResponse(log *zap.Logger, data []byte, prod bool) {
 	tdr := &goopenai.ThreadDeleteResponse{}
 	err := json.Unmarshal(data, tdr)
 	if err != nil {
@@ -107,7 +102,6 @@ func logDeleteThreadResponse(log *zap.Logger, data []byte, prod bool, cid string
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", tdr.ID),
 			zap.String("object", tdr.Object),
 			zap.Bool("deleted", tdr.Deleted),

--- a/internal/server/web/proxy/vllm.go
+++ b/internal/server/web/proxy/vllm.go
@@ -28,7 +28,6 @@ func getVllmCompletionsHandler(prod, private bool, client http.Client, timeOut t
 			return
 		}
 
-		cid := c.GetString(logFiledNameCorrelationId)
 		url := c.GetString("vllmUrl")
 		if len(url) == 0 {
 			logError(log, "vllm url cannot be empty", prod, errors.New("url is empty"))
@@ -94,7 +93,7 @@ func getVllmCompletionsHandler(prod, private bool, client http.Client, timeOut t
 			}
 
 			if err == nil {
-				logVllmCompletionResponse(log, cr, prod, private, cid)
+				logVllmCompletionResponse(log, cr, prod, private)
 			}
 
 			c.Set("promptTokenCount", cr.Usage.PromptTokens)
@@ -122,7 +121,7 @@ func getVllmCompletionsHandler(prod, private bool, client http.Client, timeOut t
 				logError(log, "error when unmarshalling openai chat completion error response body", prod, err)
 			}
 
-			logOpenAiError(log, prod, cid, errorRes)
+			logOpenAiError(log, prod, errorRes)
 
 			c.Data(res.StatusCode, "application/json", bytes)
 			return
@@ -209,11 +208,10 @@ func getVllmCompletionsHandler(prod, private bool, client http.Client, timeOut t
 	}
 }
 
-func logVllmCompletionRequest(log *zap.Logger, cr *vllm.CompletionRequest, prod, private bool, cid string) {
+func logVllmCompletionRequest(log *zap.Logger, cr *vllm.CompletionRequest, prod, private bool) {
 
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", cr.Model),
 			zap.String("suffix", cr.Suffix),
 			zap.Int("max_tokens", cr.MaxTokens),
@@ -248,10 +246,9 @@ func logVllmCompletionRequest(log *zap.Logger, cr *vllm.CompletionRequest, prod,
 	}
 }
 
-func logVllmChatCompletionRequest(log *zap.Logger, cr *vllm.ChatRequest, prod, private bool, cid string) {
+func logVllmChatCompletionRequest(log *zap.Logger, cr *vllm.ChatRequest, prod, private bool) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("model", cr.Model),
 			zap.Int("max_tokens", cr.MaxTokens),
 			zap.Float32("temperature", cr.Temperature),
@@ -319,10 +316,9 @@ func logVllmChatCompletionRequest(log *zap.Logger, cr *vllm.ChatRequest, prod, p
 	}
 }
 
-func logVllmCompletionResponse(log *zap.Logger, cr *goopenai.CompletionResponse, prod, private bool, cid string) {
+func logVllmCompletionResponse(log *zap.Logger, cr *goopenai.CompletionResponse, prod, private bool) {
 	if prod {
 		fields := []zapcore.Field{
-			zap.String(logFiledNameCorrelationId, cid),
 			zap.String("id", cr.ID),
 			zap.Int64("created", cr.Created),
 			zap.String("model", cr.Model),
@@ -359,7 +355,6 @@ func getVllmChatCompletionsHandler(prod, private bool, client http.Client, timeO
 			return
 		}
 
-		cid := c.GetString(logFiledNameCorrelationId)
 		url := c.GetString("vllmUrl")
 		if len(url) == 0 {
 			logError(log, "vllm url cannot be empty", prod, errors.New("url is empty"))
@@ -425,7 +420,7 @@ func getVllmChatCompletionsHandler(prod, private bool, client http.Client, timeO
 			}
 
 			if err == nil {
-				logChatCompletionResponse(log, prod, private, cid, chatRes)
+				logChatCompletionResponse(log, prod, private, chatRes)
 			}
 
 			c.Set("promptTokenCount", chatRes.Usage.PromptTokens)
@@ -447,7 +442,7 @@ func getVllmChatCompletionsHandler(prod, private bool, client http.Client, timeO
 				return
 			}
 
-			logAnthropicErrorResponse(log, bytes, prod, cid)
+			logAnthropicErrorResponse(log, bytes, prod)
 			c.Data(res.StatusCode, "application/json", bytes)
 			return
 		}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,20 +1,29 @@
 package util
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
 )
 
+type ctxKey string
+
 const (
-	log = "log"
+	STRING_CORRELATION_ID string = "correlationId"
+	STRING_LOG            ctxKey = "log"
 )
 
 func NewUuid() string {
 	return uuid.New().String()
 }
 
+func SetLogToCtx(c *gin.Context, logger *zap.Logger) {
+	c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), STRING_LOG, logger))
+}
+
 func GetLogFromCtx(c *gin.Context) *zap.Logger {
-	logWithCid := c.Request.Context().Value(log).(*zap.Logger)
+	logWithCid := c.Request.Context().Value(STRING_LOG).(*zap.Logger)
 	return logWithCid
 }


### PR DESCRIPTION
Hi @spikelu2016 , this PR changes all the correlation id log related code, both admin and proxy.
Now the sub logger with correlation id is stored inside the http request context. 
Whenever we can get it from the http request context whenever we need it, especially when we are in some deeper place. 
In such cases, we need to pass the http request context as the parameter to this "deeper place". 

Please feel free to let me know if you have any comments. 