### PR TITLE
Fix: Update Readme to use docker compose plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ cd BricksLLM-Docker
 
 ### Step 3 - Deploy BricksLLM locally with Postgresql and Redis
 ```bash
-docker-compose up
+docker compose up
 ```
-You can run this in detach mode use the -d flag: `docker-compose up -d`
+You can run this in detach mode use the -d flag: `docker compose up -d`
 
 
 ### Step 4 - Create a provider setting


### PR DESCRIPTION
docker-compose is pretty dated at this point and it's probably better to use `docker compose` - This also matches the suggestion in https://github.com/bricks-cloud/BricksLLM-Doc