### PR TITLE
[BugFix] Do not propagate accept-enconding header to openai server

### DIFF
--- a/internal/route/route.go
+++ b/internal/route/route.go
@@ -355,6 +355,10 @@ func (r *Route) RunSteps(req *Request, rec recorder, log *zap.Logger) (*Response
 					continue
 				}
 
+				if strings.ToLower(k) == "accept-encoding" {
+					continue
+				}
+
 				hreq.Header.Set(k, req.Forwarded.Header.Get(k))
 			}
 


### PR DESCRIPTION
we don't have any decoding the response code in here.

resolve https://github.com/bricks-cloud/BricksLLM/issues/73