### PR TITLE
Dev ll structured output support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/pkoukk/tiktoken-go v0.1.7
 	github.com/redis/go-redis/v9 v9.0.5
-	github.com/sashabaranov/go-openai v1.26.3
+	github.com/sashabaranov/go-openai v1.32.5
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.17.0
 	go.uber.org/zap v1.24.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/sashabaranov/go-openai v1.24.0 h1:4H4Pg8Bl2RH/YSnU8DYumZbuHnnkfioor/d
 github.com/sashabaranov/go-openai v1.24.0/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sashabaranov/go-openai v1.26.3 h1:Tjnh4rcvsSU68f66r05mys+Zou4vo4qyvkne6AIRJPI=
 github.com/sashabaranov/go-openai v1.26.3/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
+github.com/sashabaranov/go-openai v1.32.5 h1:/eNVa8KzlE7mJdKPZDj6886MUzZQjoVHyn0sLvIt5qA=
+github.com/sashabaranov/go-openai v1.32.5/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=

--- a/internal/manager/route.go
+++ b/internal/manager/route.go
@@ -101,6 +101,7 @@ func checkModelValidity(provider, model string) bool {
 
 var (
 	azureSupportedModels = []string{
+		"gpt-4o-2024-08-26",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",
@@ -128,6 +129,7 @@ var (
 	}
 
 	openaiSupportedModels = []string{
+		"gpt-4o-2024-08-16",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",
@@ -158,6 +160,7 @@ var (
 	}
 
 	supportedModels = []string{
+		"gpt-4o-2024-08-16",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",
@@ -212,6 +215,7 @@ var (
 		"gpt-35-turbo-0613",
 		"gpt-35-turbo-16k",
 		"gpt-35-turbo-16k-0613",
+		"gpt-4o-2024-08-16",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",

--- a/internal/manager/route.go
+++ b/internal/manager/route.go
@@ -129,7 +129,7 @@ var (
 	}
 
 	openaiSupportedModels = []string{
-		"gpt-4o-2024-08-16",
+		"gpt-4o-2024-08-06",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",
@@ -160,7 +160,7 @@ var (
 	}
 
 	supportedModels = []string{
-		"gpt-4o-2024-08-16",
+		"gpt-4o-2024-08-06",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",
@@ -215,7 +215,7 @@ var (
 		"gpt-35-turbo-0613",
 		"gpt-35-turbo-16k",
 		"gpt-35-turbo-16k-0613",
-		"gpt-4o-2024-08-16",
+		"gpt-4o-2024-08-06",
 		"gpt-4o-2024-05-13",
 		"gpt-4o",
 		"gpt-4o-mini",

--- a/internal/provider/azure/cost.go
+++ b/internal/provider/azure/cost.go
@@ -9,8 +9,11 @@ import (
 )
 
 var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
+	// updated according to this link:
+	// https://azure.microsoft.com/en-gb/pricing/details/cognitive-services/openai-service/
 	"prompt": {
-		"gpt-4o":                 0.005,
+		"gpt-4o":                 0.0025,
+		"gpt-4o-2024-08-16":      0.0025,
 		"gpt-4o-2024-05-13":      0.005,
 		"gpt-4-turbo":            0.01,
 		"gpt-4-turbo-2024-04-09": 0.01,
@@ -28,7 +31,8 @@ var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
 		"text-embedding-3-small": 0.00002,
 	},
 	"completion": {
-		"gpt-4o":                 0.015,
+		"gpt-4o":                 0.01,
+		"gpt-4o-2024-08-16":      0.01,
 		"gpt-4o-2024-05-13":      0.015,
 		"gpt-4-turbo":            0.03,
 		"gpt-4-turbo-2024-04-09": 0.03,

--- a/internal/provider/azure/cost.go
+++ b/internal/provider/azure/cost.go
@@ -12,7 +12,7 @@ var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
 	// updated according to this link:
 	// https://azure.microsoft.com/en-gb/pricing/details/cognitive-services/openai-service/
 	"prompt": {
-		"gpt-4o":                 0.0025,
+		"gpt-4o":                 0.005,
 		"gpt-4o-2024-08-16":      0.0025,
 		"gpt-4o-2024-05-13":      0.005,
 		"gpt-4-turbo":            0.01,
@@ -31,7 +31,7 @@ var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
 		"text-embedding-3-small": 0.00002,
 	},
 	"completion": {
-		"gpt-4o":                 0.01,
+		"gpt-4o":                 0.015,
 		"gpt-4o-2024-08-16":      0.01,
 		"gpt-4o-2024-05-13":      0.015,
 		"gpt-4-turbo":            0.03,

--- a/internal/provider/azure/cost.go
+++ b/internal/provider/azure/cost.go
@@ -13,7 +13,7 @@ var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
 	// https://azure.microsoft.com/en-gb/pricing/details/cognitive-services/openai-service/
 	"prompt": {
 		"gpt-4o":                 0.005,
-		"gpt-4o-2024-08-16":      0.0025,
+		"gpt-4o-2024-08-06":      0.0025,
 		"gpt-4o-2024-05-13":      0.005,
 		"gpt-4-turbo":            0.01,
 		"gpt-4-turbo-2024-04-09": 0.01,
@@ -32,7 +32,7 @@ var AzureOpenAiPerThousandTokenCost = map[string]map[string]float64{
 	},
 	"completion": {
 		"gpt-4o":                 0.015,
-		"gpt-4o-2024-08-16":      0.01,
+		"gpt-4o-2024-08-06":      0.01,
 		"gpt-4o-2024-05-13":      0.015,
 		"gpt-4-turbo":            0.03,
 		"gpt-4-turbo-2024-04-09": 0.03,


### PR DESCRIPTION
# Structured Output Support

- add `gpt-4o-2024-08-16` to supported model with cost estimation.
- upgrade `go-openai` version. current version is [1.26](https://github.com/bricks-cloud/BricksLLM/blob/main/go.mod#L20), but structured output request [1.28+](https://github.com/sashabaranov/go-openai/releases/tag/v1.28.0).